### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/BOOK-PROPOSAL.md
+++ b/BOOK-PROPOSAL.md
@@ -1,4 +1,4 @@
-# BOOK-PROPOSAL（v0.1）
+# BOOK-PROPOSAL（v1.0）
 
 ## 1. タイトル / サブタイトル
 
@@ -87,9 +87,10 @@
 - Reopen 率 / 差し戻し率の低下
 - 重要インシデント（Secrets 事故、権限逸脱）の抑止
 
-## 11. 公開形態 / ライセンス（提案）
+## 11. 公開形態 / ライセンス（決定）
 
-現時点の方針は以下。
+決定事項は以下。
 
 - 公開形態: Web（GitHub Pages）を v1.0 の前提とする（Folder: `/docs`）。電子書籍（EPUB/PDF）は v1.0 では任意。
-- ライセンス: 本文は `CC-BY-NC-SA-4.0`、サンプル/テンプレは `MIT` の分離を前提とする。
+- ライセンス（書籍本文）: `CC-BY-NC-SA-4.0`（商用は別契約。詳細は `LICENSE.md`）
+- ライセンス（サンプル/テンプレ）: Companion repo（`itdojp/GitHub-AgentOps-companion`）に集約し、`MIT` とする

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,19 @@
 
 ## [Unreleased]
 
-## [v1.0.0] - TBD
+## [v1.0.0] - 2026-02-23
 
 ### Added
 
-- 書籍本文（第1部〜第4部、章末チェックリスト含む）
-- 付録A/B/C（テンプレ一覧、プレイブック、トラブルシュート）
+- 書籍本文（第1部〜第4部、全11章 + 章末チェックリスト）
+  - 第1部（第1-2章）責任分界 / Agent-ready repo 要件
+  - 第2部（第3-5章）AGENTS.md / Skills / Rules 設計
+  - 第3部（第6-8章）GitHub Agents 運用 / `.agent.md` と MCP / コスト設計
+  - 第4部（第9-11章）Codex Action / セキュリティ / メトリクス
+- 付録A/B/C（テンプレ集、プレイブック集、トラブルシュート）
 - 検証記録: `CHECKLIST.md`
+- 公開（Web）: GitHub Pages（`main` / `/docs`）
 - Companion repo（導入資産）
   - Issue/PR テンプレ、CODEOWNERS 指針
   - Skills 雛形、Rules 雛形、`.agent.md` 雛形、MCP 公開範囲例
   - Codex GitHub Action サンプル（PR コメント/リリース前チェック）
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+# ライセンス
+
+本書籍のライセンス条件は、株式会社アイティードゥの統一ライセンスに準拠します。
+
+詳細なライセンス条件:
+https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md
+
+## 簡易説明
+
+本作品は Creative Commons BY-NC-SA 4.0 ライセンスで提供されています。
+
+- 非営利利用: 教育・研究・個人学習で自由に利用可能
+- 商用利用: 事前の商用ライセンス契約が必要
+
+お問い合わせ: knowledge@itdo.jp
+
+---
+© 2026 株式会社アイティードゥ (ITDO Inc.)
+

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+# ライセンス
+
+本書籍のライセンス条件は、株式会社アイティードゥの統一ライセンスに準拠します。
+
+詳細なライセンス条件:
+https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md
+
+## 簡易説明
+
+本作品は Creative Commons BY-NC-SA 4.0 ライセンスで提供されています。
+
+- 非営利利用: 教育・研究・個人学習で自由に利用可能
+- 商用利用: 事前の商用ライセンス契約が必要
+
+お問い合わせ: knowledge@itdo.jp
+
+---
+© 2026 株式会社アイティードゥ (ITDO Inc.)
+

--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ npm test
 - Epic: #1
 - 実行計画（ロードマップ）: #18
 - 企画書: `BOOK-PROPOSAL.md`
+
+## ライセンス
+
+CC BY-NC-SA 4.0（商用は別契約）
+
+- 詳細: `LICENSE.md`

--- a/book-config.json
+++ b/book-config.json
@@ -9,7 +9,7 @@
       "name": "ITDO Inc.",
       "github": "itdojp"
     },
-    "version": "0.1.0",
+    "version": "1.0.0",
     "language": "ja",
     "license": "CC-BY-NC-SA-4.0"
   },

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: "GitHub AgentOps 実践ガイド"
 description: "Issue→Agent→PR→反復→マージの運用を、AGENTS.md / Skills / Rules / CI で標準化するための実践ガイド。例: Codex / GitHub Agents / Copilot coding agent（主要例は Codex）。"
 author: "ITDO Inc."
-version: "0.1.0"
+version: "1.0.0"
 lang: "ja"
 
 # GitHub Pages設定

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-agentops-book",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-agentops-book",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "glob": "^10.3.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-agentops-book",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "GitHub AgentOps 実践ガイド",
   "author": "ITDO Inc.",
   "license": "CC-BY-NC-SA-4.0",


### PR DESCRIPTION
## 変更内容
- v1.0.0 向けにバージョンを揃えた（`package.json` / `book-config.json` / `docs/_config.yml` / `package-lock.json`）
- `LICENSE` / `LICENSE.md` を追加（統一ライセンス + CC BY-NC-SA 4.0）
- `CHANGELOG.md` に v1.0.0 の収録範囲を明記
- `BOOK-PROPOSAL.md` の公開形態/ライセンスを「決定」として確定
- `README.md` にライセンス導線を追加

## 検証
- `npm test`（Node v22.19.0 / npm 11.8.0）

## 関連
- Refs #17 #18
- Closes #2 #3
