### PR TITLE
[codex] Add AgentOps metadata consistency quality gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -47,6 +47,9 @@ jobs:
             echo "dir=." >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Book metadata/navigation consistency
+        run: npm run check:metadata
+
       - name: Unicode check (fail on warnings)
         run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ npm run preview
 ## 品質ゲート（ローカル）
 
 ```bash
+npm run check:metadata
 npm test
 ```
 
 実行内容:
 
+- メタデータ / ナビゲーション整合性検証
 - Markdown lint
 - ビルド（`docs/` 生成）
 - `docs/` に対する内部リンク検証

--- a/book-config.json
+++ b/book-config.json
@@ -11,7 +11,9 @@
     },
     "version": "1.0.0",
     "language": "ja",
-    "license": "CC-BY-NC-SA-4.0"
+    "license": "CC-BY-NC-SA-4.0",
+    "homepage": "https://itdojp.github.io/GitHub-AgentOps-book/",
+    "repository": "https://github.com/itdojp/GitHub-AgentOps-book"
   },
   "contentSections": [
     {

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,7 @@ lang: "ja"
 # GitHub Pages設定
 baseurl: "/GitHub-AgentOps-book"
 url: "https://itdojp.github.io"
+homepage: "https://itdojp.github.io/GitHub-AgentOps-book/"
 
 # Jekyll設定
 markdown: kramdown
@@ -31,6 +32,7 @@ plugins:
 
 # Repository information for edit links
 repository: "itdojp/GitHub-AgentOps-book"
+repository_url: "https://github.com/itdojp/GitHub-AgentOps-book"
 
 permalink: pretty
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
 ---
 layout: book
 title: "GitHub AgentOps 実践ガイド"
+description: "Issue→Agent→PR→反復→マージの運用を、Copilot instructions / AGENTS.md / Skills / custom agents / hooks / policy controls / MCP / tool exposure / CI で標準化するための実践ガイド。例: Copilot cloud agent / third-party agents（OpenAI Codex 等）/ Copilot CLI。"
+author: "ITDO Inc."
+version: "1.0.0"
 ---
 
 # GitHub AgentOps 実践ガイド

--- a/index.md
+++ b/index.md
@@ -1,6 +1,9 @@
 ---
 layout: book
 title: "GitHub AgentOps 実践ガイド"
+description: "Issue→Agent→PR→反復→マージの運用を、Copilot instructions / AGENTS.md / Skills / custom agents / hooks / policy controls / MCP / tool exposure / CI で標準化するための実践ガイド。例: Copilot cloud agent / third-party agents（OpenAI Codex 等）/ Copilot CLI。"
+author: "ITDO Inc."
+version: "1.0.0"
 ---
 
 # GitHub AgentOps 実践ガイド

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1554,12 +1554,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "github-agentops-book",
   "version": "1.0.0",
-  "description": "GitHub AgentOps 実践ガイド",
+  "description": "Issue→Agent→PR→反復→マージの運用を、Copilot instructions / AGENTS.md / Skills / custom agents / hooks / policy controls / MCP / tool exposure / CI で標準化するための実践ガイド。例: Copilot cloud agent / third-party agents（OpenAI Codex 等）/ Copilot CLI。",
   "author": "ITDO Inc.",
   "license": "CC-BY-NC-SA-4.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/itdojp/GitHub-AgentOps-book.git"
+    "url": "git+https://github.com/itdojp/GitHub-AgentOps-book.git"
   },
   "engines": {
     "node": "20 || >=22"
@@ -17,8 +17,9 @@
     "lint": "markdownlint 'src/**/*.md' 'index.md' 'README.md' 'BOOK-PROPOSAL.md' 'CONTRIBUTING.md' 'AGENTS.md' --ignore node_modules",
     "check-links": "node scripts/check-links.js",
     "build:validate": "npm run build && npm run check-links",
-    "test": "npm run lint && npm run build:validate",
-    "check-external-links": "node scripts/check-external-links.js"
+    "test": "npm run check:metadata && npm run lint && npm run build:validate",
+    "check-external-links": "node scripts/check-external-links.js",
+    "check:metadata": "node scripts/check-metadata-consistency.js"
   },
   "dependencies": {
     "glob": "^10.3.10"
@@ -26,5 +27,9 @@
   "devDependencies": {
     "http-server": "^14.1.1",
     "markdownlint-cli": "^0.47.0"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/itdojp/GitHub-AgentOps-book/issues"
+  },
+  "homepage": "https://itdojp.github.io/GitHub-AgentOps-book/"
 }

--- a/scripts/build-simple.js
+++ b/scripts/build-simple.js
@@ -394,6 +394,8 @@ Built with [Book Publishing Template v3.0](https://github.com/itdojp/book-publis
       const baseurl = repoName ? `/${repoName}` : '';
       const url = userName ? `https://${userName}.github.io` : '';
       const githubRepo = (userName && repoName) ? `${userName}/${repoName}` : '';
+      const homepage = (url && baseurl) ? `${url}${baseurl}/` : '';
+      const repositoryUrl = githubRepo ? `https://github.com/${githubRepo}` : '';
 
       const defaultConfig = `title: "${this.config.book?.title || 'My Book'}"
 description: "${this.config.book?.description || 'Book description'}"
@@ -404,6 +406,7 @@ lang: "${this.config.book?.language || 'ja'}"
 # GitHub Pages設定
 baseurl: "${baseurl}"
 url: "${url}"
+homepage: "${homepage}"
 
 # Jekyll設定
 markdown: kramdown
@@ -428,6 +431,7 @@ plugins:
 
 # Repository information for edit links
 repository: "${githubRepo}"
+repository_url: "${repositoryUrl}"
 
 permalink: pretty
 

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Validate public metadata and navigation coverage without third-party deps.
+ * The repository publishes `docs/`; this check keeps package metadata,
+ * book-config, Jekyll config, top-page front matter, and navigation in sync.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = process.cwd();
+const docs = path.join(root, 'docs');
+
+const expected = {
+  title: 'GitHub AgentOps 実践ガイド',
+  description: 'Issue→Agent→PR→反復→マージの運用を、Copilot instructions / AGENTS.md / Skills / custom agents / hooks / policy controls / MCP / tool exposure / CI で標準化するための実践ガイド。例: Copilot cloud agent / third-party agents（OpenAI Codex 等）/ Copilot CLI。',
+  author: 'ITDO Inc.',
+  version: '1.0.0',
+  license: 'CC-BY-NC-SA-4.0',
+  lang: 'ja',
+  baseurl: '/GitHub-AgentOps-book',
+  url: 'https://itdojp.github.io',
+  homepage: 'https://itdojp.github.io/GitHub-AgentOps-book/',
+  repositoryFull: 'itdojp/GitHub-AgentOps-book',
+  repositoryUrl: 'https://github.com/itdojp/GitHub-AgentOps-book',
+  repositoryGit: 'git+https://github.com/itdojp/GitHub-AgentOps-book.git',
+};
+
+const navSections = ['introduction', 'chapters', 'appendices'];
+const requiredAssets = [
+  'assets/css/main.css',
+  'assets/css/syntax-highlighting.css',
+  'assets/js/theme.js',
+  'assets/js/search.js',
+  'assets/js/code-copy-lightweight.js',
+];
+
+function fail(message) {
+  console.error(`ERROR: ${message}`);
+  process.exit(1);
+}
+
+function rel(filePath) {
+  return path.relative(root, filePath) || '.';
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    fail(`failed to read JSON ${rel(filePath)}: ${error.message}`);
+  }
+}
+
+function stripQuotes(value) {
+  const trimmed = String(value || '').trim();
+  if (trimmed.length >= 2 && trimmed[0] === trimmed[trimmed.length - 1] && ['"', "'"].includes(trimmed[0])) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function readSimpleYamlScalars(filePath) {
+  if (!fs.existsSync(filePath)) {
+    fail(`required file is missing: ${rel(filePath)}`);
+  }
+  const result = {};
+  for (const rawLine of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    if (!rawLine || /^[ \t#]/.test(rawLine) || !rawLine.includes(':')) {
+      continue;
+    }
+    const [key, ...valueParts] = rawLine.split(':');
+    const value = valueParts.join(':').trim();
+    if (!key.trim() || !value || ['|', '>'].includes(value)) {
+      continue;
+    }
+    result[key.trim()] = stripQuotes(value.replace(/\s+#.*$/, ''));
+  }
+  return result;
+}
+
+function parseFrontMatter(filePath) {
+  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+  if (lines[0] !== '---') {
+    fail(`${rel(filePath)} is missing YAML front matter`);
+  }
+  const end = lines.indexOf('---', 1);
+  if (end < 0) {
+    fail(`${rel(filePath)} has no closing front matter delimiter`);
+  }
+  const result = {};
+  for (const rawLine of lines.slice(1, end)) {
+    if (!rawLine || /^[ \t#]/.test(rawLine) || !rawLine.includes(':')) {
+      continue;
+    }
+    const [key, ...valueParts] = rawLine.split(':');
+    result[key.trim()] = stripQuotes(valueParts.join(':').trim());
+  }
+  return result;
+}
+
+function normalizePath(value) {
+  if (typeof value !== 'string') return null;
+  let route = value.trim();
+  if (!route || /^(https?:|mailto:)/.test(route)) return null;
+  if (!route.startsWith('/')) route = `/${route}`;
+  const lower = route.toLowerCase();
+  if (/\.(md|html?|pdf|txt)$/.test(lower)) return route;
+  return route.endsWith('/') ? route : `${route}/`;
+}
+
+function assertSafePath(route, label) {
+  if (!route.startsWith('/')) fail(`${label} must start with '/': ${route}`);
+  if (route.includes('\\')) fail(`${label} contains a backslash: ${route}`);
+  if (route.includes('//')) fail(`${label} contains duplicate slashes: ${route}`);
+  if (route.split('/').filter(Boolean).some((part) => part === '.' || part === '..')) {
+    fail(`${label} contains an unsafe segment: ${route}`);
+  }
+}
+
+function readNavigation(filePath) {
+  if (!fs.existsSync(filePath)) fail(`required file is missing: ${rel(filePath)}`);
+  const sections = Object.fromEntries(navSections.map((section) => [section, []]));
+  let currentSection = null;
+  let currentItem = null;
+  for (const rawLine of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.replace(/\s+$/, '');
+    const stripped = line.trim();
+    if (!stripped || stripped.startsWith('#')) continue;
+    if (!/^[ \t]/.test(line) && stripped.endsWith(':')) {
+      currentSection = stripped.slice(0, -1);
+      currentItem = null;
+      continue;
+    }
+    if (!navSections.includes(currentSection)) continue;
+    let content = stripped;
+    if (content.startsWith('- ')) {
+      currentItem = {};
+      sections[currentSection].push(currentItem);
+      content = content.slice(2).trim();
+      if (!content) continue;
+    }
+    if (!currentItem || !content.includes(':')) continue;
+    const [key, ...valueParts] = content.split(':');
+    currentItem[key.trim()] = stripQuotes(valueParts.join(':').trim());
+  }
+  return sections;
+}
+
+function markdownRoute(filePath) {
+  const frontMatter = parseFrontMatter(filePath);
+  const permalink = normalizePath(frontMatter.permalink);
+  if (permalink) return permalink;
+  const relPath = path.relative(docs, filePath).split(path.sep).join('/');
+  if (relPath === 'index.md') return '/';
+  if (relPath.endsWith('/index.md')) return `/${relPath.slice(0, -'index.md'.length)}`;
+  return `/${relPath.replace(/\.md$/, '')}/`;
+}
+
+function listMarkdownFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name.startsWith('_') || entry.name === 'assets') continue;
+      out.push(...listMarkdownFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function assertEqual(actual, expectedValue, label) {
+  if (actual !== expectedValue) {
+    fail(`${label} mismatch: expected ${JSON.stringify(expectedValue)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function checkMetadata(bookConfig, packageJson) {
+  const book = bookConfig.book || {};
+  for (const key of ['title', 'description', 'version', 'language', 'license']) {
+    assertEqual(book[key], expected[key === 'language' ? 'lang' : key], `book-config.json.book.${key}`);
+  }
+  assertEqual(book.author && book.author.name, expected.author, 'book-config.json.book.author.name');
+  assertEqual(book.homepage, expected.homepage, 'book-config.json.book.homepage');
+  assertEqual(book.repository, expected.repositoryUrl, 'book-config.json.book.repository');
+
+  assertEqual(packageJson.name, 'github-agentops-book', 'package.json.name');
+  for (const key of ['description', 'version', 'author', 'license']) {
+    assertEqual(packageJson[key], expected[key], `package.json.${key}`);
+  }
+  assertEqual(packageJson.homepage, expected.homepage, 'package.json.homepage');
+  assertEqual(packageJson.repository && packageJson.repository.type, 'git', 'package.json.repository.type');
+  assertEqual(packageJson.repository && packageJson.repository.url, expected.repositoryGit, 'package.json.repository.url');
+  assertEqual(packageJson.bugs && packageJson.bugs.url, `${expected.repositoryUrl}/issues`, 'package.json.bugs.url');
+
+  const docsConfig = readSimpleYamlScalars(path.join(docs, '_config.yml'));
+  for (const key of ['title', 'description', 'author', 'version', 'lang', 'baseurl', 'url', 'homepage']) {
+    assertEqual(docsConfig[key], expected[key], `docs/_config.yml.${key}`);
+  }
+  assertEqual(docsConfig.repository, expected.repositoryFull, 'docs/_config.yml.repository');
+  assertEqual(docsConfig.repository_url, expected.repositoryUrl, 'docs/_config.yml.repository_url');
+
+  const indexFrontMatter = parseFrontMatter(path.join(docs, 'index.md'));
+  for (const key of ['title', 'description', 'author', 'version']) {
+    assertEqual(indexFrontMatter[key], expected[key], `docs/index.md front matter ${key}`);
+  }
+}
+
+function checkNavigation(bookConfig, navSectionsData) {
+  const enabledSections = new Map((bookConfig.contentSections || [])
+    .filter((section) => section.enabled)
+    .map((section) => [section.name, section.directory]));
+  for (const section of navSections) {
+    if (!enabledSections.has(section)) {
+      fail(`book-config.json.contentSections is missing enabled section ${section}`);
+    }
+  }
+
+  const publishedRoutes = new Map();
+  for (const filePath of listMarkdownFiles(docs)) {
+    const route = markdownRoute(filePath);
+    assertSafePath(route, `published route for ${rel(filePath)}`);
+    if (publishedRoutes.has(route)) {
+      fail(`duplicate published route ${route}: ${rel(publishedRoutes.get(route))} and ${rel(filePath)}`);
+    }
+    publishedRoutes.set(route, filePath);
+  }
+
+  const navRoutes = [];
+  const seen = new Map();
+  for (const section of navSections) {
+    const items = navSectionsData[section] || [];
+    if (items.length === 0) fail(`navigation.${section} has no items`);
+    for (const [index, item] of items.entries()) {
+      const route = normalizePath(item.path);
+      if (!item.title || !route) fail(`navigation.${section}[${index + 1}] is missing title or path`);
+      assertSafePath(route, `navigation.${section}[${index + 1}].path`);
+      if (seen.has(route)) fail(`duplicate navigation path ${route}: ${seen.get(route)} and ${item.title}`);
+      seen.set(route, item.title);
+      if (!publishedRoutes.has(route)) fail(`navigation path has no docs page: ${route}`);
+      navRoutes.push(route);
+    }
+  }
+
+  const expectedRoutes = [...publishedRoutes.keys()].filter((route) => route !== '/').sort();
+  const actualRoutes = [...navRoutes].sort();
+  const missing = expectedRoutes.filter((route) => !actualRoutes.includes(route));
+  const extra = actualRoutes.filter((route) => !expectedRoutes.includes(route));
+  if (missing.length || extra.length) {
+    fail(`navigation/docs route mismatch: missing=${JSON.stringify(missing)}, extra=${JSON.stringify(extra)}`);
+  }
+
+  return { pageCount: publishedRoutes.size, navCount: navRoutes.length };
+}
+
+function checkAssets() {
+  const missing = requiredAssets.filter((asset) => {
+    const filePath = path.join(docs, asset);
+    return !fs.existsSync(filePath) || !fs.statSync(filePath).isFile() || fs.statSync(filePath).size === 0;
+  });
+  if (missing.length) fail(`required public assets are missing or empty: ${missing.join(', ')}`);
+}
+
+const bookConfig = readJson(path.join(root, 'book-config.json'));
+const packageJson = readJson(path.join(root, 'package.json'));
+const navigation = readNavigation(path.join(docs, '_data', 'navigation.yml'));
+checkMetadata(bookConfig, packageJson);
+const counts = checkNavigation(bookConfig, navigation);
+checkAssets();
+console.log(`OK: metadata and navigation coverage are consistent (${counts.navCount} navigation entries, ${counts.pageCount} docs pages)`);


### PR DESCRIPTION
## Summary
- Add a stdlib-only metadata/navigation consistency check for `book-config.json`, `package.json`, Jekyll config, front matter, navigation, and public assets.
- Add the check to local `npm test` and Book QA, and document it in the README.
- Keep generated `docs/` metadata stable by updating the root index source and build config generator.
- Refresh production lockfile transitive versions for `minimatch` / `brace-expansion` so `npm audit --omit=dev --omit=optional` is clean.

## Validation
- `npm ci`
- `npm run check:metadata`
- `npm test`
- `npm audit --omit=dev --omit=optional`
- `git diff --check`
- CI-pinned `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4` checks: unicode, textlint, internal links, layout risk, markdown structure
- Jekyll build from `docs/` and built-site smoke for top, chapter 01, chapter 11, and appendix B
- Negative fixtures: package homepage drift, missing navigation target, duplicate navigation target; CRLF front matter positive fixture

Part of itdojp/it-engineer-knowledge-architecture#167