### PR TITLE
fix: define AgentOps UX modules

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -63,6 +63,19 @@
     "enableSyntaxHighlighting": true,
     "enableAutoNavigation": false
   },
+  "ux": {
+    "profile": "B",
+    "modules": {
+      "quickStart": false,
+      "readingGuide": true,
+      "checklistPack": true,
+      "troubleshootingFlow": true,
+      "conceptMap": false,
+      "figureIndex": false,
+      "legalNotice": true,
+      "glossary": false
+    }
+  },
   "shared": {
     "version": "3.2.2",
     "lastSync": "2026-02-22T13:26:30+09:00"


### PR DESCRIPTION
## Summary

Define the missing AgentOps UX profile/modules from the fixed-SHA and public Pages audit in itdojp/it-engineer-knowledge-architecture#226.

- Profile B for practical operations/reference
- reader-facing reading guide, checklist assets, troubleshooting appendix, and license notice are true
- repository-maintainer build quick start is not treated as a reader Quick Start
- no independent concept map, figure index, or glossary is claimed
- missing Profile B figureIndex is tracked in portal #227

## Verification

- npm ci
- npm test
- npm audit --audit-level=moderate (0 vulnerabilities)
- docs Jekyll build + top-page smoke
- git diff --check

Residual Faraday / latest-http-server transitive warnings are tracked in #55.

Closes #57
