### PR TITLE
ci: update configure-pages to v6

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -81,7 +81,7 @@ jobs:
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
## Summary

- update the active `.github/workflows/book-qa.yml` from `actions/configure-pages@v5` to the Node.js 24-compatible `@v6`
- leave disabled/archive workflows, Node runtime, permissions, Jekyll inputs, and book content unchanged

## Why

The current Book QA run emits the GitHub Actions Node.js 20 deprecation annotation for repository-managed `configure-pages@v5`. The shared owner has been updated first in `itdojp/book-formatter#105`; this PR applies the repository-local minimum change.

GitHub Pages remains a GitHub-managed legacy deployment (`main:/docs`). Any annotation emitted only by `pages-build-deployment` is not changed by this source PR and is tracked separately in the parent Issue.

## Verification

- final head: `f4d6c6099a4f45e877aca9a8e147e7ef7f109a28`
- actionlint 1.7.12 on the modified `book-qa.yml`: success
- npm ci / npm audit 0 / npm test（metadata・markdownlint・build・links・figure index）: success
- `git diff --check`: success
- active `configure-pages@v5`: 0; `@v6`: 1
- exact-head Book QA: https://github.com/itdojp/GitHub-AgentOps-book/actions/runs/29298627814 success; run log / check annotationsのNode.js 20・configure-pages@v5一致は0
- repository-wide actionlint also reports pre-existing shellcheck findings in unmodified workflow files; this PR does not broaden scope to those files

Closes #61
Related: itdojp/it-engineer-knowledge-architecture#258

