### PR TITLE
Pages templateのwrite/OIDC権限をdeploy jobへ限定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "lint": "markdownlint 'src/**/*.md' 'index.md' 'README.md' 'BOOK-PROPOSAL.md' 'CONTRIBUTING.md' 'AGENTS.md' --ignore node_modules",
     "check-links": "node scripts/check-links.js",
     "build:validate": "npm run build && npm run check-links && npm run check:figures",
-    "test": "npm run check:metadata && npm run lint && npm run build:validate",
+    "test": "npm run check:metadata && npm run test:pages-template && npm run lint && npm run build:validate",
     "check-external-links": "node scripts/check-external-links.js",
     "check:metadata": "node scripts/check-metadata-consistency.js",
-    "check:figures": "node scripts/check-figure-index.js"
+    "check:figures": "node scripts/check-figure-index.js",
+    "check:pages-template": "node scripts/check-pages-template-permissions.js",
+    "test:pages-template": "node scripts/test-pages-template-permissions.js"
   },
   "dependencies": {
     "glob": "^13.0.6"

--- a/scripts/check-pages-template-permissions.js
+++ b/scripts/check-pages-template-permissions.js
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Validate the least-privilege and event-boundary contract of the Pages
+ * workflow template without adding a runtime YAML dependency.
+ *
+ * This parser intentionally understands only the indentation used by the
+ * checked template. actionlint remains responsible for full YAML validation.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const defaultWorkflowPath = path.join(
+  process.cwd(),
+  'templates',
+  'github-workflows',
+  'build-actions.yml',
+);
+
+const trustedDeployCondition =
+  "github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function linesOf(source) {
+  return source.replace(/\r\n/g, '\n').split('\n');
+}
+
+function indentation(line) {
+  const match = line.match(/^ */);
+  return match ? match[0].length : 0;
+}
+
+function findBlock(lines, key, indent, start = 0, end = lines.length) {
+  const expected = `${' '.repeat(indent)}${key}:`;
+  let first = -1;
+  for (let index = start; index < end; index += 1) {
+    if (lines[index] === expected || lines[index].startsWith(`${expected} `)) {
+      first = index;
+      break;
+    }
+  }
+  if (first < 0) fail(`required block is missing: ${key} (indent ${indent})`);
+
+  let last = end;
+  for (let index = first + 1; index < end; index += 1) {
+    const line = lines[index];
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    if (indentation(line) <= indent) {
+      last = index;
+      break;
+    }
+  }
+  return { start: first, end: last, lines: lines.slice(first, last) };
+}
+
+function scalarAfterColon(line) {
+  return line.slice(line.indexOf(':') + 1).trim();
+}
+
+function readScalarMap(block, childIndent) {
+  const result = new Map();
+  for (const line of block.lines.slice(1)) {
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    if (indentation(line) !== childIndent) continue;
+    const trimmed = line.trim();
+    if (!trimmed.includes(':')) continue;
+    const key = trimmed.slice(0, trimmed.indexOf(':'));
+    const value = scalarAfterColon(trimmed);
+    if (result.has(key)) fail(`duplicate key in ${block.lines[0].trim()}: ${key}`);
+    result.set(key, value);
+  }
+  return result;
+}
+
+function readDirectKeys(block, childIndent) {
+  const keys = [];
+  for (const line of block.lines.slice(1)) {
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    if (indentation(line) !== childIndent) continue;
+    const trimmed = line.trim();
+    const colon = trimmed.indexOf(':');
+    if (colon <= 0) fail(`unsupported direct mapping syntax in ${block.lines[0].trim()}: ${trimmed}`);
+    const key = trimmed.slice(0, colon).trim();
+    if (!/^[A-Za-z0-9_-]+$/.test(key)) {
+      fail(`unsupported direct mapping key in ${block.lines[0].trim()}: ${key}`);
+    }
+    if (keys.includes(key)) fail(`duplicate direct mapping key in ${block.lines[0].trim()}: ${key}`);
+    keys.push(key);
+  }
+  return keys;
+}
+
+function assertExactPermissions(actual, expected, label) {
+  const actualEntries = [...actual.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const expectedEntries = Object.entries(expected).sort(([a], [b]) => a.localeCompare(b));
+  if (JSON.stringify(actualEntries) !== JSON.stringify(expectedEntries)) {
+    fail(`${label} permissions mismatch: expected ${JSON.stringify(expectedEntries)}, got ${JSON.stringify(actualEntries)}`);
+  }
+}
+
+function findStep(job, name) {
+  const expected = `- name: ${name}`;
+  for (let index = 0; index < job.lines.length; index += 1) {
+    if (job.lines[index].trim() !== expected) continue;
+    const indent = indentation(job.lines[index]);
+    let end = job.lines.length;
+    for (let cursor = index + 1; cursor < job.lines.length; cursor += 1) {
+      const line = job.lines[cursor];
+      if (!line.trim() || line.trimStart().startsWith('#')) continue;
+      if (indentation(line) === indent && line.trimStart().startsWith('- ')) {
+        end = cursor;
+        break;
+      }
+      if (indentation(line) < indent) {
+        end = cursor;
+        break;
+      }
+    }
+    return job.lines.slice(index, end);
+  }
+  fail(`required step is missing from ${job.lines[0].trim()}: ${name}`);
+}
+
+function readStepScalar(stepLines, key) {
+  const prefix = `${key}:`;
+  const line = stepLines.find((candidate) => candidate.trim().startsWith(prefix));
+  if (!line) fail(`required step key is missing: ${key}`);
+  return scalarAfterColon(line.trim());
+}
+
+function readJobScalar(job, key) {
+  const prefix = `${key}:`;
+  const jobIndent = indentation(job.lines[0]);
+  const line = job.lines.slice(1).find((candidate) => (
+    indentation(candidate) === jobIndent + 2 && candidate.trim().startsWith(prefix)
+  ));
+  if (!line) fail(`required job key is missing from ${job.lines[0].trim()}: ${key}`);
+  return scalarAfterColon(line.trim());
+}
+
+function validateWorkflow(source) {
+  const lines = linesOf(source);
+  if (lines.some((line) => /\t/.test(line))) fail('tabs are not allowed in the workflow template');
+
+  const eventBlock = findBlock(lines, 'on', 0);
+  for (const event of ['push', 'pull_request', 'workflow_dispatch']) {
+    findBlock(lines, event, 2, eventBlock.start + 1, eventBlock.end);
+  }
+
+  const workflowPermissions = findBlock(lines, 'permissions', 0);
+  assertExactPermissions(
+    readScalarMap(workflowPermissions, 2),
+    { contents: 'read' },
+    'workflow default',
+  );
+
+  const jobs = findBlock(lines, 'jobs', 0);
+  const jobNames = readDirectKeys(jobs, 2);
+  if (JSON.stringify(jobNames) !== JSON.stringify(['build', 'deploy'])) {
+    fail(`jobs must be exactly ["build","deploy"]; got ${JSON.stringify(jobNames)}`);
+  }
+  const build = findBlock(lines, 'build', 2, jobs.start + 1, jobs.end);
+  const deploy = findBlock(lines, 'deploy', 2, jobs.start + 1, jobs.end);
+
+  const buildPermissions = findBlock(build.lines, 'permissions', 4);
+  assertExactPermissions(
+    readScalarMap(buildPermissions, 6),
+    { contents: 'read' },
+    'build job',
+  );
+
+  const deployPermissions = findBlock(deploy.lines, 'permissions', 4);
+  assertExactPermissions(
+    readScalarMap(deployPermissions, 6),
+    { pages: 'write', 'id-token': 'write' },
+    'deploy job',
+  );
+
+  if (readJobScalar(deploy, 'if') !== trustedDeployCondition) {
+    fail('deploy job must be limited to main push or main workflow_dispatch');
+  }
+  if (readJobScalar(deploy, 'needs') !== 'build') fail('deploy job must need the build job');
+
+  const environment = findBlock(deploy.lines, 'environment', 4);
+  const environmentMap = readScalarMap(environment, 6);
+  if (environmentMap.get('name') !== 'github-pages') {
+    fail('deploy job must use the github-pages environment');
+  }
+
+  const upload = findStep(build, 'Upload artifact');
+  if (readStepScalar(upload, 'if') !== trustedDeployCondition) {
+    fail('Pages artifact upload must be limited to main push or main workflow_dispatch');
+  }
+
+  const deployStep = findStep(deploy, 'Deploy to GitHub Pages');
+  if (!readStepScalar(deployStep, 'uses').startsWith('actions/deploy-pages@')) {
+    fail('deploy job must contain actions/deploy-pages');
+  }
+
+  return {
+    events: ['push', 'pull_request', 'workflow_dispatch'],
+    jobs: jobNames,
+    workflowPermissions: Object.fromEntries(readScalarMap(workflowPermissions, 2)),
+    buildPermissions: Object.fromEntries(readScalarMap(buildPermissions, 6)),
+    deployPermissions: Object.fromEntries(readScalarMap(deployPermissions, 6)),
+  };
+}
+
+function main() {
+  const workflowPath = process.argv[2] ? path.resolve(process.argv[2]) : defaultWorkflowPath;
+  let source;
+  try {
+    source = fs.readFileSync(workflowPath, 'utf8');
+  } catch (error) {
+    console.error(`ERROR: failed to read ${path.relative(process.cwd(), workflowPath)}: ${error.message}`);
+    process.exit(1);
+  }
+
+  try {
+    const result = validateWorkflow(source);
+    console.log(`OK: Pages template least-privilege contract is valid (${JSON.stringify(result)})`);
+  } catch (error) {
+    console.error(`ERROR: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { trustedDeployCondition, validateWorkflow };

--- a/scripts/test-pages-template-permissions.js
+++ b/scripts/test-pages-template-permissions.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { validateWorkflow } = require('./check-pages-template-permissions');
+
+const workflowPath = path.join(
+  process.cwd(),
+  'templates',
+  'github-workflows',
+  'build-actions.yml',
+);
+const source = fs.readFileSync(workflowPath, 'utf8');
+
+function replaceOccurrence(input, search, replacement, occurrence) {
+  let from = 0;
+  let index = -1;
+  for (let count = 0; count < occurrence; count += 1) {
+    index = input.indexOf(search, from);
+    assert(index >= 0, `fixture source occurrence ${occurrence} must exist: ${search}`);
+    from = index + search.length;
+  }
+  return `${input.slice(0, index)}${replacement}${input.slice(index + search.length)}`;
+}
+
+const expectedResult = validateWorkflow(source);
+assert.deepStrictEqual(expectedResult.workflowPermissions, { contents: 'read' });
+assert.deepStrictEqual(expectedResult.buildPermissions, { contents: 'read' });
+assert.deepStrictEqual(expectedResult.deployPermissions, {
+  pages: 'write',
+  'id-token': 'write',
+});
+assert(expectedResult.events.includes('pull_request'));
+
+function mayPublish({ eventName, ref }) {
+  return ref === 'refs/heads/main'
+    && (eventName === 'push' || eventName === 'workflow_dispatch');
+}
+
+const eventMatrix = [
+  { name: 'fork pull request', eventName: 'pull_request', ref: 'refs/pull/101/merge', publish: false },
+  { name: 'internal pull request', eventName: 'pull_request', ref: 'refs/pull/102/merge', publish: false },
+  { name: 'main push', eventName: 'push', ref: 'refs/heads/main', publish: true },
+  { name: 'main manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/main', publish: true },
+  { name: 'feature manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/feature', publish: false },
+];
+for (const scenario of eventMatrix) {
+  assert.strictEqual(mayPublish(scenario), scenario.publish, scenario.name);
+}
+
+const negativeFixtures = [
+  {
+    name: 'workflow-level Pages write permission',
+    source: source.replace('permissions:\n  contents: read\n', 'permissions:\n  contents: read\n  pages: write\n'),
+    message: /workflow default permissions mismatch/,
+  },
+  {
+    name: 'build job OIDC permission',
+    source: source.replace(
+      '    permissions:\n      contents: read\n',
+      '    permissions:\n      contents: read\n      id-token: write\n',
+    ),
+    message: /build job permissions mismatch/,
+  },
+  {
+    name: 'additional privileged job',
+    source: source.replace(
+      '  deploy:\n',
+      '  audit:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: write\n    steps:\n      - run: echo unsafe\n\n  deploy:\n',
+    ),
+    message: /jobs must be exactly/,
+  },
+  {
+    name: 'additional inline privileged job',
+    source: source.replace(
+      '  deploy:\n',
+      '  audit: { runs-on: ubuntu-latest, permissions: { contents: write }, steps: [ { run: echo unsafe } ] }\n\n  deploy:\n',
+    ),
+    message: /jobs must be exactly/,
+  },
+  {
+    name: 'missing deploy OIDC permission',
+    source: source.replace('      id-token: write\n', ''),
+    message: /deploy job permissions mismatch/,
+  },
+  {
+    name: 'deploy allowed on any push',
+    source: replaceOccurrence(
+      source,
+      "if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')",
+      "if: github.event_name == 'push'",
+      2,
+    ),
+    message: /deploy job must be limited/,
+  },
+  {
+    name: 'artifact upload allowed on pull request',
+    source: source.replace(
+      "        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')",
+      "        if: github.event_name == 'pull_request'",
+    ),
+    message: /artifact upload must be limited/,
+  },
+  {
+    name: 'missing pull_request event',
+    source: source.replace('  pull_request:\n    branches: [ main ]\n', ''),
+    message: /required block is missing: pull_request/,
+  },
+];
+
+for (const fixture of negativeFixtures) {
+  assert.throws(
+    () => validateWorkflow(fixture.source),
+    fixture.message,
+    `${fixture.name} fixture must fail`,
+  );
+}
+
+console.log(`OK: Pages template permission tests passed (${eventMatrix.length} event scenarios, 1 positive, ${negativeFixtures.length} negative fixtures)`);

--- a/templates/github-workflows/README.md
+++ b/templates/github-workflows/README.md
@@ -20,7 +20,13 @@
 - **特徴**:
   - 新しい方式
   - artifact uploadとdeploy jobを分離
+  - workflow既定とbuild jobは`contents: read`のみ
+  - `pages: write`と`id-token: write`はdeploy jobだけに付与
+  - internal PRとfork PRはいずれもread-onlyのbuild jobだけを実行し、artifact uploadとdeploy jobはスキップ
   - より高度な制御が可能
+
+`build-actions.yml`のdeploy条件は、`main`へのpushまたは`main`上の手動実行（`workflow_dispatch`）だけを許可します。
+`pull_request`イベントは、fork元にかかわらずbuild jobのlint/build確認だけを実行し、Pagesへの書き込みやOIDC tokenの発行を行いません。
 
 ## セットアップ手順
 

--- a/templates/github-workflows/README.md
+++ b/templates/github-workflows/README.md
@@ -26,7 +26,7 @@
   - より高度な制御が可能
 
 `build-actions.yml`のdeploy条件は、`main`へのpushまたは`main`上の手動実行（`workflow_dispatch`）だけを許可します。
-`pull_request`イベントは、fork元にかかわらずbuild jobのlint/build確認だけを実行し、Pagesへの書き込みやOIDC tokenの発行を行いません。
+`pull_request`イベントは、fork元にかかわらずbuild jobのbuild確認だけを実行し、Pagesへの書き込みやOIDC tokenの発行を行いません。
 
 ## セットアップ手順
 

--- a/templates/github-workflows/build-actions.yml
+++ b/templates/github-workflows/build-actions.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -19,6 +17,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # pull_request（forkを含む）は、このread-only jobだけを実行する。
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -39,12 +41,14 @@ jobs:
           npm run build
 
       - name: Upload artifact
+        # PRではartifactを作成せず、deploy jobも起動しない。
         if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
 
   deploy:
+    # pull_request（forkを含む）は、この条件を満たさない。
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

Pages workflow templateの権限境界をleast privilegeへ変更し、PR（forkを含む）ではread-only buildだけを実行する契約を固定します。

Refs #66

## 変更

- workflow defaultとbuild jobを`contents: read`のみに限定
- `pages: write` / `id-token: write`をdeploy jobだけに限定
- PRではPages artifact upload / deployを実行しないことをtemplate説明へ明記
- 権限、event、job構成を検査するdependency-free checkerを追加
- fork/internal PR、main push、manual dispatchのevent matrixと8 negative fixturesを`npm test`へ追加

## 検証

- `mise exec node@24 -- npm ci`
- `mise exec node@24 -- npm test`
- `mise exec node@24 -- npm audit --omit=dev --omit=optional`（0 vulnerabilities）
- `actionlint templates/github-workflows/build-actions.yml`
- `git diff --check`
- 独立security review: 初回指摘（第三jobのchecker bypass）を修正し、block/inline mapping両fixtureで再検証、最終actionable finding 0

## スコープ分離

- Action SHA pinning / driftは #67 で扱い、本PRではaction refを変更しません。
- 固定concurrency groupの可用性論点は #69 へ分離しました。
- Pages deployment方式自体は変更しません。
