### PR TITLE
Actions参照を監査済みfull-length SHAへpinする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: actions

--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -17,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout book
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Checkout book-formatter (pinned)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: itdojp/book-formatter
           ref: 69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c
           path: book-formatter
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
           cache: npm
@@ -50,6 +50,12 @@ jobs:
       - name: Book metadata/navigation consistency
         run: npm run check:metadata
 
+      - name: Audited GitHub Actions SHA pin policy
+        run: npm run test:action-pins
+
+      - name: Workflow and template syntax
+        run: npm run check:workflows
+
       - name: Unicode check (fail on warnings)
         run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
 
@@ -67,7 +73,7 @@ jobs:
 
       - name: Upload markdown structure report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: markdown-structure-report
           path: ${{ runner.temp }}/markdown-structure-report.json
@@ -75,16 +81,16 @@ jobs:
 
       - name: Upload layout risk report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: layout-risk-report
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build (Jekyll; GitHub Pages compatible)
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:
           source: ./${{ steps.scan.outputs.dir }}
           destination: ./_site

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/docs-forbidden-check.yml
+++ b/.github/workflows/docs-forbidden-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check forbidden items in docs
         shell: bash
         run: |

--- a/.github/workflows/nav-link-check.yml
+++ b/.github/workflows/nav-link-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install PyYAML
         run: python3 -m pip install --user pyyaml
@@ -73,17 +73,17 @@ jobs:
           Path('urls.txt').write_text(out, encoding='utf-8')
           print(out)
           PY
-          echo "list=urls.txt" >> $GITHUB_OUTPUT
+          echo "list=urls.txt" >> "$GITHUB_OUTPUT"
 
       - name: Probe URLs
         run: |
           failures=0
           while IFS=$'\t' read -r path url; do
             code=$(curl -s -o /dev/null -w "%{http_code}" -L "$url")
-            echo "$code $url"
+            echo "$code $path $url"
             if [ "$code" != "200" ]; then failures=$((failures+1)); fi
           done < urls.txt
-          if [ $failures -gt 0 ]; then
+          if [ "$failures" -gt 0 ]; then
             echo "Found $failures non-200 URLs" >&2
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ npm test
 - ビルド（`docs/` 生成）
 - `docs/` に対する内部リンク検証
 
+actionlint gateはLinux/macOSのx86_64/arm64に対応し、OS/CPU別の公式release assetをSHA-256検証して実行します。
+
 ## オンライン版
 
 - GitHub Pages: https://itdojp.github.io/GitHub-AgentOps-book/

--- a/README.md
+++ b/README.md
@@ -35,12 +35,16 @@ npm run preview
 
 ```bash
 npm run check:metadata
+npm run check:action-pins
+npm run check:workflows
 npm test
 ```
 
 実行内容:
 
 - メタデータ / ナビゲーション整合性検証
+- active workflow / templateの監査済みAction SHA pin検証
+- checksum固定したactionlintによるworkflow / template構文検証
 - Markdown lint
 - ビルド（`docs/` 生成）
 - `docs/` に対する内部リンク検証

--- a/config/action-pins.json
+++ b/config/action-pins.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "auditedAt": "2026-07-19",
+  "actions": [
+    {
+      "name": "actions/checkout",
+      "version": "v6.0.3",
+      "sha": "df4cb1c069e1874edd31b4311f1884172cec0e10",
+      "releaseUrl": "https://github.com/actions/checkout/releases/tag/v6.0.3",
+      "verifiedCommit": true
+    },
+    {
+      "name": "actions/configure-pages",
+      "version": "v6.0.0",
+      "sha": "45bfe0192ca1faeb007ade9deae92b16b8254a0d",
+      "releaseUrl": "https://github.com/actions/configure-pages/releases/tag/v6.0.0",
+      "verifiedCommit": true
+    },
+    {
+      "name": "actions/deploy-pages",
+      "version": "v5.0.0",
+      "sha": "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128",
+      "releaseUrl": "https://github.com/actions/deploy-pages/releases/tag/v5.0.0",
+      "verifiedCommit": true
+    },
+    {
+      "name": "actions/jekyll-build-pages",
+      "version": "v1.0.13",
+      "sha": "44a6e6beabd48582f863aeeb6cb2151cc1716697",
+      "releaseUrl": "https://github.com/actions/jekyll-build-pages/releases/tag/v1.0.13",
+      "verifiedCommit": true
+    },
+    {
+      "name": "actions/setup-node",
+      "version": "v6.5.0",
+      "sha": "249970729cb0ef3589644e2896645e5dc5ba9c38",
+      "releaseUrl": "https://github.com/actions/setup-node/releases/tag/v6.5.0",
+      "verifiedCommit": true
+    },
+    {
+      "name": "actions/upload-artifact",
+      "version": "v7.0.1",
+      "sha": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      "releaseUrl": "https://github.com/actions/upload-artifact/releases/tag/v7.0.1",
+      "verifiedCommit": true
+    },
+    {
+      "name": "actions/upload-pages-artifact",
+      "version": "v5.0.0",
+      "sha": "fc324d3547104276b827a68afc52ff2a11cc49c9",
+      "releaseUrl": "https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0",
+      "verifiedCommit": true
+    }
+  ],
+  "references": [
+    { "file": ".github/workflows/book-qa.yml", "action": "actions/checkout", "count": 2 },
+    { "file": ".github/workflows/book-qa.yml", "action": "actions/configure-pages", "count": 1 },
+    { "file": ".github/workflows/book-qa.yml", "action": "actions/jekyll-build-pages", "count": 1 },
+    { "file": ".github/workflows/book-qa.yml", "action": "actions/setup-node", "count": 1 },
+    { "file": ".github/workflows/book-qa.yml", "action": "actions/upload-artifact", "count": 2 },
+    { "file": ".github/workflows/build.yml", "action": "actions/checkout", "count": 1 },
+    { "file": ".github/workflows/build.yml", "action": "actions/setup-node", "count": 1 },
+    { "file": ".github/workflows/docs-forbidden-check.yml", "action": "actions/checkout", "count": 1 },
+    { "file": ".github/workflows/nav-link-check.yml", "action": "actions/checkout", "count": 1 },
+    { "file": "templates/github-workflows/build-actions.yml", "action": "actions/checkout", "count": 1 },
+    { "file": "templates/github-workflows/build-actions.yml", "action": "actions/deploy-pages", "count": 1 },
+    { "file": "templates/github-workflows/build-actions.yml", "action": "actions/setup-node", "count": 1 },
+    { "file": "templates/github-workflows/build-actions.yml", "action": "actions/upload-pages-artifact", "count": 1 },
+    { "file": "templates/github-workflows/build-legacy.yml", "action": "actions/checkout", "count": 1 },
+    { "file": "templates/github-workflows/build-legacy.yml", "action": "actions/setup-node", "count": 1 }
+  ]
+}

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -161,6 +161,21 @@ GitHub の secure use reference では、Action を full-length commit SHA に p
 一方で、SHA pin は更新運用の負荷を増やすため、重要 workflow から段階導入します。
 更新は Dependabot / Renovate 等で PR 化し、理由、影響、検証、rollback をセットで review します。
 
+### Action SHA pin の更新契約
+
+full-length SHA は、version tagをコメントに残しただけでは監査済みになりません。更新PRでは次の順序を守ります。
+
+1. upstreamのofficial releaseとexact version tagを確認し、tagとmajor aliasをcommitまでdereferenceする
+2. candidate commit、署名・verification、`action.yml`、runtime、入力・出力・権限、transitive `uses:`、changelogを確認する
+3. active workflowと配布templateを同じ監査済みSHAへ同期し、human-readableなexact version commentを併記する
+4. `config/action-pins.json`へ確認日、release URL、SHAを記録する
+5. `npm run test:action-pins`、`actionlint`、repository CI、template smokeを実行する
+6. 問題があれば、直前の監査済みSHAへ戻し、失敗条件と再開条件を更新PRへ残す
+
+Dependabotの`github-actions`更新は監査開始の通知であり、自動承認ではありません。
+active workflowだけが自動更新されてtemplateやmanifestと不一致になった場合、pin gateを失敗させ、監査と同期が終わるまでmergeしません。
+mutableなmajor tagへ戻してCIだけを通す運用は、供給網の再現性を失うため禁止します。
+
 ## artifact attestations / SBOM
 
 release artifact、container image、CLI binary、重要な build output は、artifact attestations で provenance を残します。

--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
     "lint": "markdownlint 'src/**/*.md' 'index.md' 'README.md' 'BOOK-PROPOSAL.md' 'CONTRIBUTING.md' 'AGENTS.md' --ignore node_modules",
     "check-links": "node scripts/check-links.js",
     "build:validate": "npm run build && npm run check-links && npm run check:figures",
-    "test": "npm run check:metadata && npm run test:pages-template && npm run lint && npm run build:validate",
+    "test": "npm run check:metadata && npm run test:pages-template && npm run test:action-pins && npm run check:workflows && npm run lint && npm run build:validate",
     "check-external-links": "node scripts/check-external-links.js",
     "check:metadata": "node scripts/check-metadata-consistency.js",
     "check:figures": "node scripts/check-figure-index.js",
     "check:pages-template": "node scripts/check-pages-template-permissions.js",
-    "test:pages-template": "node scripts/test-pages-template-permissions.js"
+    "test:pages-template": "node scripts/test-pages-template-permissions.js",
+    "check:action-pins": "node scripts/check-action-pins.js",
+    "test:action-pins": "node scripts/test-action-pins.js",
+    "check:workflows": "bash scripts/check-workflow-yaml.sh"
   },
   "dependencies": {
     "glob": "^13.0.6"

--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Enforce audited, immutable GitHub Action references in active workflows and
+ * distributed workflow templates. Full YAML syntax remains actionlint's job;
+ * this checker deliberately permits only a canonical, reviewable `uses:` line.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = process.cwd();
+const manifestPath = path.join(root, 'config', 'action-pins.json');
+const scanRoots = ['.github/workflows', 'templates/github-workflows'];
+const shaPattern = /^[0-9a-f]{40}$/;
+const versionPattern = /^v\d+\.\d+\.\d+$/;
+const actionNamePattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.\/-]+)?$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function normalizeManifest(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) fail('manifest must be an object');
+  if (raw.schemaVersion !== 1) fail(`manifest schemaVersion must be 1, got ${raw.schemaVersion}`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw.auditedAt || '')) fail('manifest auditedAt must be YYYY-MM-DD');
+  if (!Array.isArray(raw.actions) || raw.actions.length === 0) fail('manifest actions must be a non-empty array');
+
+  const approved = new Map();
+  for (const [index, entry] of raw.actions.entries()) {
+    const label = `manifest actions[${index}]`;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) fail(`${label} must be an object`);
+    if (!actionNamePattern.test(entry.name || '')) fail(`${label}.name is invalid: ${entry.name}`);
+    if (!versionPattern.test(entry.version || '')) fail(`${label}.version must be exact semver: ${entry.version}`);
+    if (!shaPattern.test(entry.sha || '')) fail(`${label}.sha must be 40 lowercase hex: ${entry.sha}`);
+    if (entry.verifiedCommit !== true) fail(`${label}.verifiedCommit must be true`);
+    const [owner, repository] = entry.name.split('/');
+    const expectedUrl = `https://github.com/${owner}/${repository}/releases/tag/${entry.version}`;
+    if (entry.releaseUrl !== expectedUrl) {
+      fail(`${label}.releaseUrl mismatch: expected ${expectedUrl}, got ${entry.releaseUrl}`);
+    }
+    if (approved.has(entry.name)) fail(`duplicate manifest action: ${entry.name}`);
+    approved.set(entry.name, { ...entry });
+  }
+
+  if (!Array.isArray(raw.references) || raw.references.length === 0) {
+    fail('manifest references must be a non-empty array');
+  }
+  const expectedReferences = new Map();
+  for (const [index, entry] of raw.references.entries()) {
+    const label = `manifest references[${index}]`;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) fail(`${label} must be an object`);
+    if (!/^(?:\.github\/workflows|templates\/github-workflows)\/.+\.ya?ml$/i.test(entry.file || '')) {
+      fail(`${label}.file is outside the action scan roots: ${entry.file}`);
+    }
+    if (!approved.has(entry.action)) fail(`${label}.action is not approved: ${entry.action}`);
+    if (!Number.isInteger(entry.count) || entry.count <= 0) fail(`${label}.count must be a positive integer`);
+    const key = `${entry.file}\u0000${entry.action}`;
+    if (expectedReferences.has(key)) fail(`duplicate manifest reference: ${entry.file} ${entry.action}`);
+    expectedReferences.set(key, entry.count);
+  }
+  for (const name of approved.keys()) {
+    if (![...expectedReferences.keys()].some((key) => key.endsWith(`\u0000${name}`))) {
+      fail(`approved action has no expected reference: ${name}`);
+    }
+  }
+  return { auditedAt: raw.auditedAt, approved, expectedReferences };
+}
+
+function readManifest(filePath = manifestPath) {
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    fail(`failed to read action pin manifest: ${error.message}`);
+  }
+  return normalizeManifest(raw);
+}
+
+function assertWithinRoot(candidate, rootPath, label) {
+  const relative = path.relative(rootPath, candidate);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) fail(`${label} escapes repository root: ${candidate}`);
+}
+
+function collectYamlFiles(repositoryRoot = root, roots = scanRoots) {
+  const repositoryReal = fs.realpathSync(repositoryRoot);
+  const files = new Map();
+
+  function visit(candidate) {
+    const stat = fs.lstatSync(candidate);
+    if (stat.isSymbolicLink()) fail(`symlink is not allowed under action scan roots: ${path.relative(repositoryReal, candidate)}`);
+    const real = fs.realpathSync(candidate);
+    assertWithinRoot(real, repositoryReal, 'scan path');
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(candidate).sort()) visit(path.join(candidate, entry));
+      return;
+    }
+    if (!stat.isFile() || !/\.ya?ml$/i.test(candidate)) return;
+    const relative = path.relative(repositoryReal, real).split(path.sep).join('/');
+    files.set(relative, fs.readFileSync(real, 'utf8'));
+  }
+
+  for (const relativeRoot of roots) {
+    const absolute = path.resolve(repositoryReal, relativeRoot);
+    assertWithinRoot(absolute, repositoryReal, 'scan root');
+    if (!fs.existsSync(absolute)) fail(`required action scan root is missing: ${relativeRoot}`);
+    visit(absolute);
+  }
+  if (files.size === 0) fail('action scan roots contain no YAML files');
+  return files;
+}
+
+function indentation(line) {
+  const match = line.match(/^ */);
+  return match ? match[0].length : 0;
+}
+
+function parseCanonicalUses(value, location) {
+  const trimmed = value.trim();
+  if (!trimmed) fail(`${location}: uses value is empty`);
+  if (trimmed.startsWith('"') || trimmed.startsWith("'")) {
+    fail(`${location}: remote uses values must be unquoted canonical scalars`);
+  }
+  const commentMatch = trimmed.match(/^(\S+)\s+#\s+(\S+)\s*$/);
+  const scalar = commentMatch ? commentMatch[1] : trimmed;
+  const versionComment = commentMatch ? commentMatch[2] : null;
+
+  if (scalar.startsWith('./') || scalar.startsWith('docker://')) return { ignored: true };
+  if (scalar.includes('${{') || scalar.includes('}}')) fail(`${location}: dynamic remote uses values are not allowed`);
+  const at = scalar.lastIndexOf('@');
+  if (at <= 0 || at === scalar.length - 1) fail(`${location}: remote uses must be action@sha: ${scalar}`);
+  const name = scalar.slice(0, at);
+  const sha = scalar.slice(at + 1);
+  if (!actionNamePattern.test(name)) fail(`${location}: invalid remote action name: ${name}`);
+  if (!shaPattern.test(sha)) fail(`${location}: remote action ref must be 40 lowercase hex: ${scalar}`);
+  if (!versionComment) fail(`${location}: exact version comment is required for ${name}`);
+  return { ignored: false, name, sha, versionComment };
+}
+
+function validateInventory(files, manifest) {
+  if (!(files instanceof Map) || files.size === 0) fail('files must be a non-empty Map');
+  const normalizedManifest = manifest.approved instanceof Map ? manifest : normalizeManifest(manifest);
+  const usageCounts = new Map([...normalizedManifest.approved.keys()].map((name) => [name, 0]));
+  const referenceInventory = new Map();
+  let referenceCount = 0;
+
+  for (const [fileName, source] of [...files.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    if (!/\.ya?ml$/i.test(fileName)) fail(`inventory contains a non-YAML file: ${fileName}`);
+    const lines = String(source).replace(/\r\n/g, '\n').split('\n');
+    let blockScalarIndent = null;
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      const trimmed = line.trim();
+      const currentIndent = indentation(line);
+      if (blockScalarIndent !== null) {
+        if (!trimmed || currentIndent > blockScalarIndent) continue;
+        blockScalarIndent = null;
+      }
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const canonical = line.match(/^\s*(?:-\s*)?uses\s*:\s*(.*?)\s*$/);
+      if (canonical) {
+        const parsed = parseCanonicalUses(canonical[1], `${fileName}:${index + 1}`);
+        if (parsed.ignored) continue;
+        const approved = normalizedManifest.approved.get(parsed.name);
+        if (!approved) fail(`${fileName}:${index + 1}: action is not in the audited manifest: ${parsed.name}`);
+        if (parsed.sha !== approved.sha) {
+          fail(`${fileName}:${index + 1}: SHA mismatch for ${parsed.name}: expected ${approved.sha}, got ${parsed.sha}`);
+        }
+        if (parsed.versionComment !== approved.version) {
+          fail(`${fileName}:${index + 1}: version comment mismatch for ${parsed.name}: expected ${approved.version}, got ${parsed.versionComment}`);
+        }
+        const inventoryKey = `${fileName}\u0000${parsed.name}`;
+        referenceInventory.set(inventoryKey, (referenceInventory.get(inventoryKey) || 0) + 1);
+        usageCounts.set(parsed.name, usageCounts.get(parsed.name) + 1);
+        referenceCount += 1;
+        continue;
+      }
+
+      if (/^[^#]*:\s*[>|][-+]?\s*(?:#.*)?$/.test(line)) {
+        blockScalarIndent = currentIndent;
+        continue;
+      }
+
+      if (!canonical) {
+        if (/\buses\b\s*['"]?\s*:/.test(line) || /uses\s*:[^#]*@/.test(line)) {
+          fail(`${fileName}:${index + 1}: uses must be a standalone canonical mapping line`);
+        }
+        continue;
+      }
+    }
+  }
+
+  const stale = [...usageCounts.entries()].filter(([, count]) => count === 0).map(([name]) => name);
+  if (stale.length) fail(`audited manifest contains unused actions: ${stale.join(', ')}`);
+  const actualReferences = [...referenceInventory.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const expectedReferences = [...normalizedManifest.expectedReferences.entries()].sort(([a], [b]) => a.localeCompare(b));
+  if (JSON.stringify(actualReferences) !== JSON.stringify(expectedReferences)) {
+    const format = (entries) => entries.map(([key, count]) => {
+      const [file, action] = key.split('\u0000');
+      return `${file}:${action}=${count}`;
+    });
+    fail(`reference inventory mismatch: expected ${JSON.stringify(format(expectedReferences))}, got ${JSON.stringify(format(actualReferences))}`);
+  }
+  return {
+    auditedAt: normalizedManifest.auditedAt,
+    fileCount: files.size,
+    actionCount: normalizedManifest.approved.size,
+    referenceCount,
+    usageCounts: Object.fromEntries([...usageCounts.entries()].sort(([a], [b]) => a.localeCompare(b))),
+  };
+}
+
+function main() {
+  try {
+    const result = validateInventory(collectYamlFiles(), readManifest());
+    console.log(`OK: audited Action pins are consistent (${result.referenceCount} refs, ${result.actionCount} actions, ${result.fileCount} YAML files, audited ${result.auditedAt})`);
+  } catch (error) {
+    console.error(`ERROR: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  collectYamlFiles,
+  normalizeManifest,
+  parseCanonicalUses,
+  readManifest,
+  validateInventory,
+};

--- a/scripts/check-workflow-yaml.sh
+++ b/scripts/check-workflow-yaml.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Official release asset pin. Update version, URL, and SHA-256 together after
+# reviewing https://github.com/rhysd/actionlint/releases.
+readonly ACTIONLINT_VERSION='1.7.12'
+readonly ACTIONLINT_SHA256='8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'
+readonly ACTIONLINT_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+readonly CACHE_DIR="${ACTIONLINT_CACHE_DIR:-node_modules/.cache/actionlint-${ACTIONLINT_VERSION}}"
+readonly ARCHIVE="${CACHE_DIR}/actionlint.tar.gz"
+readonly BINARY="${CACHE_DIR}/actionlint"
+
+mkdir -p "${CACHE_DIR}"
+if [[ ! -f "${ARCHIVE}" ]]; then
+  curl --proto '=https' --tlsv1.2 --location --fail --silent --show-error \
+    --retry 3 --retry-all-errors --output "${ARCHIVE}" "${ACTIONLINT_URL}"
+fi
+printf '%s  %s\n' "${ACTIONLINT_SHA256}" "${ARCHIVE}" | sha256sum --check --status || {
+  printf 'ERROR: actionlint archive checksum mismatch: %s\n' "${ARCHIVE}" >&2
+  exit 1
+}
+tar -xzf "${ARCHIVE}" -C "${CACHE_DIR}" actionlint
+
+mapfile -d '' workflow_files < <(
+  find .github/workflows templates/github-workflows -type f \
+    \( -name '*.yml' -o -name '*.yaml' \) -print0 | sort -z
+)
+if [[ ${#workflow_files[@]} -eq 0 ]]; then
+  printf 'ERROR: no workflow/template YAML files found\n' >&2
+  exit 1
+fi
+
+"${BINARY}" "${workflow_files[@]}"
+printf 'OK: actionlint %s checked %d workflow/template files\n' \
+  "${ACTIONLINT_VERSION}" "${#workflow_files[@]}"

--- a/scripts/check-workflow-yaml.sh
+++ b/scripts/check-workflow-yaml.sh
@@ -1,30 +1,56 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Official release asset pin. Update version, URL, and SHA-256 together after
-# reviewing https://github.com/rhysd/actionlint/releases.
+# Official release asset pins. Update version, asset SHA-256 values, and URL
+# together after reviewing https://github.com/rhysd/actionlint/releases.
 readonly ACTIONLINT_VERSION='1.7.12'
-readonly ACTIONLINT_SHA256='8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'
-readonly ACTIONLINT_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-readonly CACHE_DIR="${ACTIONLINT_CACHE_DIR:-node_modules/.cache/actionlint-${ACTIONLINT_VERSION}}"
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    readonly ACTIONLINT_ASSET="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+    readonly ACTIONLINT_SHA256='8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'
+    ;;
+  Linux-aarch64 | Linux-arm64)
+    readonly ACTIONLINT_ASSET="actionlint_${ACTIONLINT_VERSION}_linux_arm64.tar.gz"
+    readonly ACTIONLINT_SHA256='325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6'
+    ;;
+  Darwin-x86_64)
+    readonly ACTIONLINT_ASSET="actionlint_${ACTIONLINT_VERSION}_darwin_amd64.tar.gz"
+    readonly ACTIONLINT_SHA256='5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644'
+    ;;
+  Darwin-arm64)
+    readonly ACTIONLINT_ASSET="actionlint_${ACTIONLINT_VERSION}_darwin_arm64.tar.gz"
+    readonly ACTIONLINT_SHA256='aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f'
+    ;;
+  *)
+    printf 'ERROR: actionlint gate supports Linux/macOS on x86_64/arm64; got %s/%s\n' \
+      "$(uname -s)" "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+readonly ACTIONLINT_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ACTIONLINT_ASSET}"
+readonly CACHE_DIR="${ACTIONLINT_CACHE_DIR:-node_modules/.cache/actionlint-${ACTIONLINT_VERSION}-$(uname -s)-$(uname -m)}"
 readonly ARCHIVE="${CACHE_DIR}/actionlint.tar.gz"
 readonly BINARY="${CACHE_DIR}/actionlint"
 
 mkdir -p "${CACHE_DIR}"
 if [[ ! -f "${ARCHIVE}" ]]; then
   curl --proto '=https' --tlsv1.2 --location --fail --silent --show-error \
-    --retry 3 --retry-all-errors --output "${ARCHIVE}" "${ACTIONLINT_URL}"
+    --retry 3 --retry-delay 2 --output "${ARCHIVE}" "${ACTIONLINT_URL}"
 fi
-printf '%s  %s\n' "${ACTIONLINT_SHA256}" "${ARCHIVE}" | sha256sum --check --status || {
+actual_sha256="$(node -e \
+  'const crypto=require("crypto"),fs=require("fs"); console.log(crypto.createHash("sha256").update(fs.readFileSync(process.argv[1])).digest("hex"));' \
+  "${ARCHIVE}")"
+if [[ "${actual_sha256}" != "${ACTIONLINT_SHA256}" ]]; then
   printf 'ERROR: actionlint archive checksum mismatch: %s\n' "${ARCHIVE}" >&2
   exit 1
-}
+fi
 tar -xzf "${ARCHIVE}" -C "${CACHE_DIR}" actionlint
 
-mapfile -d '' workflow_files < <(
-  find .github/workflows templates/github-workflows -type f \
-    \( -name '*.yml' -o -name '*.yaml' \) -print0 | sort -z
-)
+workflow_files=()
+while IFS= read -r -d '' workflow_file; do
+  workflow_files+=("${workflow_file}")
+done < <(find .github/workflows templates/github-workflows -type f \
+  \( -name '*.yml' -o -name '*.yaml' \) -print0)
 if [[ ${#workflow_files[@]} -eq 0 ]]; then
   printf 'ERROR: no workflow/template YAML files found\n' >&2
   exit 1

--- a/scripts/test-action-pins.js
+++ b/scripts/test-action-pins.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const {
+  collectYamlFiles,
+  readManifest,
+  validateInventory,
+} = require('./check-action-pins');
+
+const files = collectYamlFiles();
+const manifest = readManifest();
+const positive = validateInventory(files, manifest);
+assert.strictEqual(positive.actionCount, 7);
+assert.strictEqual(positive.referenceCount, 17);
+assert.strictEqual(positive.fileCount, 6);
+
+function cloneFiles() {
+  return new Map(files);
+}
+
+function mutateFirst(search, replacement) {
+  const changed = cloneFiles();
+  for (const [name, source] of changed) {
+    if (!source.includes(search)) continue;
+    changed.set(name, source.replace(search, replacement));
+    return changed;
+  }
+  assert.fail(`fixture search value not found: ${search}`);
+}
+
+function rawManifest() {
+  return {
+    schemaVersion: 1,
+    auditedAt: manifest.auditedAt,
+    actions: [...manifest.approved.values()].map((entry) => ({ ...entry })),
+    references: [...manifest.expectedReferences.entries()].map(([key, count]) => {
+      const [file, action] = key.split('\u0000');
+      return { file, action, count };
+    }),
+  };
+}
+
+const checkoutSha = manifest.approved.get('actions/checkout').sha;
+const checkoutVersion = manifest.approved.get('actions/checkout').version;
+const canonicalCheckout = `actions/checkout@${checkoutSha} # ${checkoutVersion}`;
+const negativeFixtures = [
+  {
+    name: 'mutable major tag',
+    files: mutateFirst(canonicalCheckout, 'actions/checkout@v6 # v6'),
+    manifest,
+    message: /must be 40 lowercase hex/,
+  },
+  {
+    name: 'short SHA',
+    files: mutateFirst(canonicalCheckout, `actions/checkout@${checkoutSha.slice(0, 12)} # ${checkoutVersion}`),
+    manifest,
+    message: /must be 40 lowercase hex/,
+  },
+  {
+    name: 'unapproved full SHA',
+    files: mutateFirst(canonicalCheckout, `example/unapproved@${checkoutSha} # ${checkoutVersion}`),
+    manifest,
+    message: /not in the audited manifest/,
+  },
+  {
+    name: 'wrong version comment',
+    files: mutateFirst(canonicalCheckout, `actions/checkout@${checkoutSha} # v6.0.2`),
+    manifest,
+    message: /version comment mismatch/,
+  },
+  {
+    name: 'missing version comment',
+    files: mutateFirst(canonicalCheckout, `actions/checkout@${checkoutSha}`),
+    manifest,
+    message: /exact version comment is required/,
+  },
+  {
+    name: 'quoted remote ref',
+    files: mutateFirst(canonicalCheckout, `"actions/checkout@${checkoutSha}" # ${checkoutVersion}`),
+    manifest,
+    message: /must be unquoted canonical scalars/,
+  },
+  {
+    name: 'dynamic remote ref',
+    files: mutateFirst(canonicalCheckout, '${{ matrix.action }}'),
+    manifest,
+    message: /dynamic remote uses values are not allowed/,
+  },
+  {
+    name: 'block scalar mutable ref',
+    files: mutateFirst(canonicalCheckout, '> -\n          actions/checkout@v6'.replace('> -', '>-')),
+    manifest,
+    message: /remote uses must be action@sha/,
+  },
+  {
+    name: 'extra yaml file with mutable ref',
+    files: new Map([...files, ['templates/github-workflows/nested/extra.yaml', 'jobs:\n  extra:\n    steps:\n      - uses: actions/checkout@v6\n']]),
+    manifest,
+    message: /must be 40 lowercase hex/,
+  },
+  {
+    name: 'inline mapping bypass',
+    files: new Map([...files, ['templates/github-workflows/inline.yml', `steps:\n  - { uses: actions/checkout@${checkoutSha} }\n`]]),
+    manifest,
+    message: /standalone canonical mapping line/,
+  },
+  {
+    name: 'aggregate count compensation in another file',
+    files: (() => {
+      const changed = cloneFiles();
+      const sourceFile = '.github/workflows/docs-forbidden-check.yml';
+      const targetFile = '.github/workflows/build.yml';
+      changed.set(sourceFile, changed.get(sourceFile).replace(`      - uses: ${canonicalCheckout}\n`, ''));
+      changed.set(targetFile, changed.get(targetFile).replace(
+        `      - uses: ${canonicalCheckout}\n`,
+        `      - uses: ${canonicalCheckout}\n      - uses: ${canonicalCheckout}\n`,
+      ));
+      return changed;
+    })(),
+    manifest,
+    message: /reference inventory mismatch/,
+  },
+  {
+    name: 'stale manifest entry',
+    files,
+    manifest: {
+      ...rawManifest(),
+      actions: [
+        ...rawManifest().actions,
+        {
+          name: 'actions/cache',
+          version: 'v4.0.0',
+          sha: '0123456789abcdef0123456789abcdef01234567',
+          releaseUrl: 'https://github.com/actions/cache/releases/tag/v4.0.0',
+          verifiedCommit: true,
+        },
+      ],
+    },
+    message: /approved action has no expected reference: actions\/cache/,
+  },
+];
+
+for (const fixture of negativeFixtures) {
+  assert.throws(
+    () => validateInventory(fixture.files, fixture.manifest),
+    fixture.message,
+    `${fixture.name} fixture must fail`,
+  );
+}
+
+console.log(`OK: Action pin tests passed (1 positive, ${negativeFixtures.length} negative fixtures, ${positive.referenceCount} refs)`);

--- a/src/chapters/chapter10/index.md
+++ b/src/chapters/chapter10/index.md
@@ -156,6 +156,21 @@ GitHub の secure use reference では、Action を full-length commit SHA に p
 一方で、SHA pin は更新運用の負荷を増やすため、重要 workflow から段階導入します。
 更新は Dependabot / Renovate 等で PR 化し、理由、影響、検証、rollback をセットで review します。
 
+### Action SHA pin の更新契約
+
+full-length SHA は、version tagをコメントに残しただけでは監査済みになりません。更新PRでは次の順序を守ります。
+
+1. upstreamのofficial releaseとexact version tagを確認し、tagとmajor aliasをcommitまでdereferenceする
+2. candidate commit、署名・verification、`action.yml`、runtime、入力・出力・権限、transitive `uses:`、changelogを確認する
+3. active workflowと配布templateを同じ監査済みSHAへ同期し、human-readableなexact version commentを併記する
+4. `config/action-pins.json`へ確認日、release URL、SHAを記録する
+5. `npm run test:action-pins`、`actionlint`、repository CI、template smokeを実行する
+6. 問題があれば、直前の監査済みSHAへ戻し、失敗条件と再開条件を更新PRへ残す
+
+Dependabotの`github-actions`更新は監査開始の通知であり、自動承認ではありません。
+active workflowだけが自動更新されてtemplateやmanifestと不一致になった場合、pin gateを失敗させ、監査と同期が終わるまでmergeしません。
+mutableなmajor tagへ戻してCIだけを通す運用は、供給網の再現性を失うため禁止します。
+
 ## artifact attestations / SBOM
 
 release artifact、container image、CLI binary、重要な build output は、artifact attestations で provenance を残します。

--- a/templates/github-workflows/README.md
+++ b/templates/github-workflows/README.md
@@ -28,6 +28,12 @@
 `build-actions.yml`のdeploy条件は、`main`へのpushまたは`main`上の手動実行（`workflow_dispatch`）だけを許可します。
 `pull_request`イベントは、fork元にかかわらずbuild jobのbuild確認だけを実行し、Pagesへの書き込みやOIDC tokenの発行を行いません。
 
+両templateのremote Action参照は、監査済みのfull-length commit SHAとexact version commentを組にして管理します。
+copy後もmutableなmajor tagへ戻さず、更新時はupstream release/tag/commit、runtime、入出力、権限、transitive `uses:`を確認してください。
+本リポジトリでは`config/action-pins.json`を監査記録の正本とし、`npm run test:action-pins`でactive workflowとtemplateのdriftを検出します。
+Dependabotがactive workflowのSHAを更新した場合も、template、manifest、version comment、監査証跡を同期するまでmergeしません。
+このv5 templateはGitHub.comのPagesを対象とします。GitHub Enterprise Serverで使う場合は、[`actions/deploy-pages`のcompatibility表](https://github.com/actions/deploy-pages#compatibility)でserver versionに対応するrelease lineを確認してください。
+
 ## セットアップ手順
 
 1. プロジェクトに`.github/workflows/`ディレクトリを作成

--- a/templates/github-workflows/build-actions.yml
+++ b/templates/github-workflows/build-actions.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '18'
           cache: 'npm'
@@ -43,9 +43,11 @@ jobs:
       - name: Upload artifact
         # PRではartifactを作成せず、deploy jobも起動しない。
         if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./docs
+          # v5 excludes hidden files by default; preserve the v3 template behavior.
+          include-hidden-files: true
 
   deploy:
     # pull_request（forkを含む）は、この条件を満たさない。
@@ -64,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/templates/github-workflows/build-legacy.yml
+++ b/templates/github-workflows/build-legacy.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '18'
           cache: 'npm'


### PR DESCRIPTION
## 概要

active workflowと配布templateの17 remote Action参照を、上流で監査したfull-length commit SHAへ固定し、drift/更新契約をCI化します。

Refs #67

## 監査済みpin

| Action | Version | SHA |
| --- | --- | --- |
| `actions/checkout` | `v6.0.3` | `df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `actions/setup-node` | `v6.5.0` | `249970729cb0ef3589644e2896645e5dc5ba9c38` |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/configure-pages` | `v6.0.0` | `45bfe0192ca1faeb007ade9deae92b16b8254a0d` |
| `actions/jekyll-build-pages` | `v1.0.13` | `44a6e6beabd48582f863aeeb6cb2151cc1716697` |
| `actions/upload-pages-artifact` | `v5.0.0` | `fc324d3547104276b827a68afc52ff2a11cc49c9` |
| `actions/deploy-pages` | `v5.0.0` | `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` |

GitHub APIでofficial release、exact tag、major alias、commitまでdereferenceし、candidate/major alias一致、commit verification `verified=true/reason=valid`、`action.yml`存在を確認しました。前5件は現在のmajor aliasと同じcodeをimmutable化しています。

Pages templateは、v3 uploadのtransitive mutable `upload-artifact@v4`を解消し、deploy runtimeをNode 24へ移すためv5を採用しました。upload v5の内部pinもverified commitで、hidden-fileの既存挙動は`include-hidden-files: true`で維持します。

## 変更

- 17/17 refsをSHA + exact version commentへ変更
- `config/action-pins.json`へ7 actionとfile/action/count exact inventoryを記録
- 再帰・symlink-safe checkerと12 negative fixturesを追加
- mutable/short/unapproved/quoted/dynamic/block scalar/inline/nested/aggregate-count compensation/stale manifestを拒否
- checksum固定`actionlint 1.7.12`を`npm test`とBook QAへ接続
- actionlint導入で顕在化した既存shell引用2件を最小修正
- GitHub Actions Dependabotを週次設定し、template/manifest未同期PRをpin gateで停止
- Chapter 10 / READMEへ監査、rollback、GHES境界を記載

## 検証

- `npm ci`、`npm test`、`npm run build`
- `npm audit --omit=dev --omit=optional`: 0 vulnerabilities
- Action pin checker: 17 refs / 7 actions / 6 YAML files
- actionlint 1.7.12: 6 workflow/template files PASS
- Jekyll build / top + Chapter 10 marker smoke PASS
- Dependabot YAML parse PASS
- mutable active/template ref: 0
- `shellcheck scripts/check-workflow-yaml.sh`、Node syntax、`git diff --check`: PASS
- independent security review: initial High 1 / Low 1を修正し、final actionable 0

## スコープ分離

- #68のcompanion path、#69のconcurrencyは未変更
- Actions以外のdependencyとorganization allowlistは未変更
- transitive Actionの継続確認はdocumented audit contractで扱い、top-level local inventoryと区別
