### PR TITLE
PR #75のlate Companion review指摘へ対応する

### DIFF
--- a/scripts/check-companion-assets.js
+++ b/scripts/check-companion-assets.js
@@ -156,8 +156,8 @@ function validateRepository(root = process.cwd()) {
   if (!Array.isArray(catalog.shippedAssets) || catalog.shippedAssets.length === 0) {
     errors.push('shippedAssets must be a non-empty array');
   }
-  if (!Array.isArray(catalog.plannedAssets) || catalog.plannedAssets.length === 0) {
-    errors.push('plannedAssets must be a non-empty array');
+  if (!Array.isArray(catalog.plannedAssets)) {
+    errors.push('plannedAssets must be an array');
   }
   if (!Array.isArray(catalog.scannedDocuments) || catalog.scannedDocuments.length === 0) {
     errors.push('scannedDocuments must be a non-empty array');
@@ -375,6 +375,7 @@ async function validateRemote(root = process.cwd()) {
 
   const remote = new Map(tree.tree.map((item) => [item.path, item]));
   const remoteBlobs = new Set(tree.tree.filter((item) => item.type === 'blob').map((item) => item.path));
+  const shippedPaths = new Set(catalog.shippedAssets.map((asset) => asset.path));
   const errors = [];
   for (const asset of catalog.shippedAssets) {
     const item = remote.get(asset.path);
@@ -387,7 +388,7 @@ async function validateRemote(root = process.cwd()) {
     }
   }
   for (const remotePath of remoteBlobs) {
-    if (!catalog.shippedAssets.some((asset) => asset.path === remotePath)) {
+    if (!shippedPaths.has(remotePath)) {
       errors.push(`pinned snapshot blob is missing from shippedAssets: ${remotePath}`);
     }
   }

--- a/scripts/test-companion-assets.js
+++ b/scripts/test-companion-assets.js
@@ -49,11 +49,38 @@ function expectFailure(name, mutate, pattern) {
   throw new Error(`${name}: checker accepted an invalid fixture`);
 }
 
+function expectSuccess(name, mutate) {
+  const target = path.join(fixtureRoot, name);
+  copyFixture(target);
+  mutate(target);
+  try {
+    validateRepository(target);
+  } catch (error) {
+    throw new Error(`${name}: checker rejected a valid fixture: ${error.message}`);
+  }
+}
+
 fs.rmSync(fixtureRoot, { recursive: true, force: true });
 fs.mkdirSync(fixtureRoot, { recursive: true });
 
 try {
   validateRepository(root);
+
+  expectSuccess('empty-planned-assets', (target) => {
+    const plannedPaths = catalog.plannedAssets.map((asset) => asset.path);
+    mutateJson(target, (data) => {
+      data.plannedAssets = [];
+      data.inventory.plannedAssets = 0;
+    });
+    for (const relativePath of catalog.scannedDocuments) {
+      const file = path.join(target, relativePath);
+      const content = plannedPaths.reduce(
+        (updated, plannedPath) => updated.replaceAll(plannedPath, 'retired-planned-asset'),
+        fs.readFileSync(file, 'utf8')
+      );
+      fs.writeFileSync(file, content);
+    }
+  });
 
   expectFailure(
     'unregistered-path',
@@ -360,7 +387,7 @@ try {
     /public generic document must not link/
   );
 
-  console.log('Companion asset fixtures: 1 positive, 26 negative passed');
+  console.log('Companion asset fixtures: 2 positive, 26 negative passed');
 } finally {
   fs.rmSync(fixtureRoot, { recursive: true, force: true });
 }


### PR DESCRIPTION
## 概要

Merged PR #75 に merge 後到着した Copilot の2件のレビュー指摘へ対応します。

- `plannedAssets: []` を、全planned assetがshippedへ移行した将来の正当な状態として許容
- remote snapshotのblob membershipを事前計算した`Set`で判定し、tree拡大時の二次走査を回避
- empty `plannedAssets` のpositive fixtureを追加

Follow-up to #75. Relates #68.

## 検証

- `mise exec node@24 -- npm ci`
- `mise exec node@24 -- npm test`
- `mise exec node@24 -- npm audit --omit=dev --omit=optional`（0 vulnerabilities）
- `mise exec node@24 -- npm run check:companion-assets:remote`（27 shipped / 23 planned / 16 documents）
- `mise exec node@24 -- npm run check-external-links`（66 links）
- Jekyll build + root / Chapter 2 / Appendix A smoke
- `git diff --check`
- independent correctness review: High/Medium 0、actionable 0（deterministic remote unit test欠如はLow。live remote checkとscheduled workflowで確認）
