### PR TITLE
PR buildとPages deployのconcurrency境界を分離する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- GitHub Actions Pages templateのconcurrencyをPR buildとtrusted deployへ分離し、同一PRの旧buildだけをcancelしながら進行中deployを保護する契約と回帰テストを追加した
 - Companion固定pathをcommit-pinned catalogへ統合し、実在する `shipped` 資産と未提供の `planned / not yet shipped` 候補を分離した。local fixture検査と週次/手動remote tree検査を追加した
 - 最終整合性検証として README / CHECKLIST / 外部リンク検証スクリプトを更新し、Issue #37 の残受入基準を確認可能にした
 - 付録A/B/Cを現行 ecosystem 向けに再構成し、instructions / agents / Skills / hooks / MCP、Copilot review、Actions permissions、MCP/tool exposure、rollout review のテンプレ・プレイブック・トラブルシュートを追加

--- a/scripts/check-pages-template-permissions.js
+++ b/scripts/check-pages-template-permissions.js
@@ -22,8 +22,9 @@ const defaultWorkflowPath = path.join(
 const trustedDeployCondition =
   "github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')";
 const buildConcurrencyGroup =
-  "${{ github.workflow }}-build-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}";
-const buildCancelInProgress = "${{ github.event_name == 'pull_request' }}";
+  "${{ github.workflow }}-build-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.ref == 'refs/heads/main' && 'pages' || format('run-{0}', github.run_id)) }}";
+const buildCancelInProgress =
+  "${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}";
 const deployConcurrencyGroup = '${{ github.workflow }}-pages-deploy';
 
 function fail(message) {

--- a/scripts/check-pages-template-permissions.js
+++ b/scripts/check-pages-template-permissions.js
@@ -21,6 +21,10 @@ const defaultWorkflowPath = path.join(
 
 const trustedDeployCondition =
   "github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')";
+const buildConcurrencyGroup =
+  "${{ github.workflow }}-build-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}";
+const buildCancelInProgress = "${{ github.event_name == 'pull_request' }}";
+const deployConcurrencyGroup = '${{ github.workflow }}-pages-deploy';
 
 function fail(message) {
   throw new Error(message);
@@ -33,6 +37,20 @@ function linesOf(source) {
 function indentation(line) {
   const match = line.match(/^ */);
   return match ? match[0].length : 0;
+}
+
+function isNamedMappingKey(line, expectedKey) {
+  const trimmed = line.trim();
+  const colon = trimmed.indexOf(':');
+  if (colon < 0) return false;
+  const rawKey = trimmed.slice(0, colon).trim();
+  if (rawKey === expectedKey || rawKey === `'${expectedKey}'`) return true;
+  if (!rawKey.startsWith('"') || !rawKey.endsWith('"')) return false;
+  try {
+    return JSON.parse(rawKey) === expectedKey;
+  } catch {
+    return false;
+  }
 }
 
 function findBlock(lines, key, indent, start = 0, end = lines.length) {
@@ -95,12 +113,16 @@ function readDirectKeys(block, childIndent) {
   return keys;
 }
 
-function assertExactPermissions(actual, expected, label) {
+function assertExactScalarMap(actual, expected, label) {
   const actualEntries = [...actual.entries()].sort(([a], [b]) => a.localeCompare(b));
   const expectedEntries = Object.entries(expected).sort(([a], [b]) => a.localeCompare(b));
   if (JSON.stringify(actualEntries) !== JSON.stringify(expectedEntries)) {
-    fail(`${label} permissions mismatch: expected ${JSON.stringify(expectedEntries)}, got ${JSON.stringify(actualEntries)}`);
+    fail(`${label} mismatch: expected ${JSON.stringify(expectedEntries)}, got ${JSON.stringify(actualEntries)}`);
   }
+}
+
+function assertExactPermissions(actual, expected, label) {
+  assertExactScalarMap(actual, expected, `${label} permissions`);
 }
 
 function findStep(job, name) {
@@ -146,6 +168,9 @@ function readJobScalar(job, key) {
 function validateWorkflow(source) {
   const lines = linesOf(source);
   if (lines.some((line) => /\t/.test(line))) fail('tabs are not allowed in the workflow template');
+  if (lines.some((line) => indentation(line) === 0 && isNamedMappingKey(line, 'concurrency'))) {
+    fail('workflow-level concurrency must not mix PR builds with Pages deploys');
+  }
 
   const eventBlock = findBlock(lines, 'on', 0);
   for (const event of ['push', 'pull_request', 'workflow_dispatch']) {
@@ -166,6 +191,20 @@ function validateWorkflow(source) {
   }
   const build = findBlock(lines, 'build', 2, jobs.start + 1, jobs.end);
   const deploy = findBlock(lines, 'deploy', 2, jobs.start + 1, jobs.end);
+
+  const buildConcurrency = findBlock(build.lines, 'concurrency', 4);
+  assertExactScalarMap(
+    readScalarMap(buildConcurrency, 6),
+    { group: buildConcurrencyGroup, 'cancel-in-progress': buildCancelInProgress },
+    'build concurrency',
+  );
+
+  const deployConcurrency = findBlock(deploy.lines, 'concurrency', 4);
+  assertExactScalarMap(
+    readScalarMap(deployConcurrency, 6),
+    { group: deployConcurrencyGroup, 'cancel-in-progress': 'false' },
+    'deploy concurrency',
+  );
 
   const buildPermissions = findBlock(build.lines, 'permissions', 4);
   assertExactPermissions(
@@ -208,6 +247,8 @@ function validateWorkflow(source) {
     workflowPermissions: Object.fromEntries(readScalarMap(workflowPermissions, 2)),
     buildPermissions: Object.fromEntries(readScalarMap(buildPermissions, 6)),
     deployPermissions: Object.fromEntries(readScalarMap(deployPermissions, 6)),
+    buildConcurrency: Object.fromEntries(readScalarMap(buildConcurrency, 6)),
+    deployConcurrency: Object.fromEntries(readScalarMap(deployConcurrency, 6)),
   };
 }
 
@@ -232,4 +273,10 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { trustedDeployCondition, validateWorkflow };
+module.exports = {
+  buildCancelInProgress,
+  buildConcurrencyGroup,
+  deployConcurrencyGroup,
+  trustedDeployCondition,
+  validateWorkflow,
+};

--- a/scripts/check-pages-template-permissions.js
+++ b/scripts/check-pages-template-permissions.js
@@ -40,18 +40,66 @@ function indentation(line) {
   return match ? match[0].length : 0;
 }
 
+function decodeYamlDoubleQuotedScalar(raw) {
+  if (!raw.startsWith('"') || !raw.endsWith('"')) return null;
+
+  const simpleEscapes = new Map([
+    ['0', '\0'],
+    ['a', '\x07'],
+    ['b', '\b'],
+    ['t', '\t'],
+    ['n', '\n'],
+    ['v', '\v'],
+    ['f', '\f'],
+    ['r', '\r'],
+    ['e', '\x1b'],
+    [' ', ' '],
+    ['"', '"'],
+    ['/', '/'],
+    ['\\', '\\'],
+    ['N', '\x85'],
+    ['_', '\xa0'],
+    ['L', '\u2028'],
+    ['P', '\u2029'],
+  ]);
+  const hexWidths = new Map([['x', 2], ['u', 4], ['U', 8]]);
+  let decoded = '';
+
+  for (let index = 1; index < raw.length - 1; index += 1) {
+    const character = raw[index];
+    if (character !== '\\') {
+      decoded += character;
+      continue;
+    }
+
+    index += 1;
+    if (index >= raw.length - 1) return null;
+    const escape = raw[index];
+    if (simpleEscapes.has(escape)) {
+      decoded += simpleEscapes.get(escape);
+      continue;
+    }
+
+    const width = hexWidths.get(escape);
+    if (!width) return null;
+    const digits = raw.slice(index + 1, index + 1 + width);
+    if (digits.length !== width || !/^[0-9A-Fa-f]+$/.test(digits)) return null;
+    const codePoint = Number.parseInt(digits, 16);
+    if (codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) return null;
+    decoded += String.fromCodePoint(codePoint);
+    index += width;
+  }
+
+  return decoded;
+}
+
 function isNamedMappingKey(line, expectedKey) {
   const trimmed = line.trim();
   const colon = trimmed.indexOf(':');
   if (colon < 0) return false;
   const rawKey = trimmed.slice(0, colon).trim();
   if (rawKey === expectedKey || rawKey === `'${expectedKey}'`) return true;
-  if (!rawKey.startsWith('"') || !rawKey.endsWith('"')) return false;
-  try {
-    return JSON.parse(rawKey) === expectedKey;
-  } catch {
-    return false;
-  }
+  return decodeYamlDoubleQuotedScalar(rawKey) === expectedKey;
 }
 
 function findBlock(lines, key, indent, start = 0, end = lines.length) {
@@ -277,6 +325,7 @@ if (require.main === module) main();
 module.exports = {
   buildCancelInProgress,
   buildConcurrencyGroup,
+  decodeYamlDoubleQuotedScalar,
   deployConcurrencyGroup,
   trustedDeployCondition,
   validateWorkflow,

--- a/scripts/test-pages-template-permissions.js
+++ b/scripts/test-pages-template-permissions.js
@@ -60,17 +60,20 @@ const eventMatrix = [
   { name: 'same pull request update', eventName: 'pull_request', ref: 'refs/pull/101/merge', prNumber: 101, runId: 1002, publish: false },
   { name: 'internal pull request', eventName: 'pull_request', ref: 'refs/pull/102/merge', prNumber: 102, runId: 1003, publish: false },
   { name: 'main push', eventName: 'push', ref: 'refs/heads/main', runId: 2001, publish: true },
-  { name: 'main manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/main', runId: 2002, publish: true },
-  { name: 'feature manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/feature', runId: 2003, publish: false },
+  { name: 'newer main push', eventName: 'push', ref: 'refs/heads/main', runId: 2002, publish: true },
+  { name: 'main manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/main', runId: 2003, publish: true },
+  { name: 'feature manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/feature', runId: 2004, publish: false },
 ];
 
 function concurrencyPolicy(scenario) {
-  const buildSuffix = scenario.eventName === 'pull_request'
-    ? `pr-${scenario.prNumber}`
-    : `run-${scenario.runId}`;
+  let buildSuffix;
+  if (scenario.eventName === 'pull_request') buildSuffix = `pr-${scenario.prNumber}`;
+  else if (scenario.ref === 'refs/heads/main') buildSuffix = 'pages';
+  else buildSuffix = `run-${scenario.runId}`;
   return {
     buildGroup: `${workflowName}-build-${buildSuffix}`,
-    cancelBuildInProgress: scenario.eventName === 'pull_request',
+    cancelBuildInProgress:
+      scenario.eventName === 'pull_request' || scenario.ref === 'refs/heads/main',
     deployGroup: mayPublish(scenario)
       ? `${workflowName}-pages-deploy`
       : null,
@@ -86,11 +89,17 @@ assert.strictEqual(policies[0].buildGroup, policies[1].buildGroup, 'same PR must
 assert(policies[0].cancelBuildInProgress, 'same PR update must cancel the older build');
 assert.notStrictEqual(policies[0].buildGroup, policies[2].buildGroup, 'different PRs must not cancel each other');
 assert.notStrictEqual(policies[0].buildGroup, policies[3].deployGroup, 'PR build must not share the deploy group');
-assert.strictEqual(policies[3].deployGroup, policies[4].deployGroup, 'main push/manual deploys must serialize');
+assert.strictEqual(policies[3].buildGroup, policies[4].buildGroup, 'main pushes must share the trusted build group');
+assert(policies[3].cancelBuildInProgress, 'a newer main push must cancel an older main build');
+assert(policies[4].cancelBuildInProgress, 'a newer main push must cancel an older main build');
+assert.strictEqual(policies[3].buildGroup, policies[5].buildGroup, 'main push/manual builds must share the trusted build group');
+assert(policies[5].cancelBuildInProgress, 'a main manual build must supersede an older trusted build');
+assert.strictEqual(policies[3].deployGroup, policies[5].deployGroup, 'main push/manual deploys must serialize');
 assert(!policies[3].cancelDeployInProgress, 'a main push must not cancel an active deploy');
-assert(!policies[4].cancelDeployInProgress, 'a manual deploy must not cancel an active deploy');
-assert.notStrictEqual(policies[3].buildGroup, policies[4].buildGroup, 'non-PR builds must use unique run groups');
-assert.strictEqual(policies[5].deployGroup, null, 'feature manual run must not join the deploy group');
+assert(!policies[5].cancelDeployInProgress, 'a manual deploy must not cancel an active deploy');
+assert.notStrictEqual(policies[3].buildGroup, policies[6].buildGroup, 'non-main manual build must use a unique run group');
+assert(!policies[6].cancelBuildInProgress, 'non-main manual build must not cancel another run');
+assert.strictEqual(policies[6].deployGroup, null, 'feature manual run must not join the deploy group');
 
 const negativeFixtures = [
   {
@@ -180,7 +189,7 @@ const negativeFixtures = [
     message: /build concurrency mismatch/,
   },
   {
-    name: 'PR group without non-PR fallback',
+    name: 'PR group without trusted-main and non-main fallback',
     source: source.replace(
       `      group: ${buildConcurrencyGroup}\n`,
       "      group: ${{ github.workflow }}-build-pr-${{ github.event.pull_request.number }}\n",

--- a/scripts/test-pages-template-permissions.js
+++ b/scripts/test-pages-template-permissions.js
@@ -4,7 +4,12 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const { validateWorkflow } = require('./check-pages-template-permissions');
+const {
+  buildCancelInProgress,
+  buildConcurrencyGroup,
+  deployConcurrencyGroup,
+  validateWorkflow,
+} = require('./check-pages-template-permissions');
 
 const workflowPath = path.join(
   process.cwd(),
@@ -32,6 +37,14 @@ assert.deepStrictEqual(expectedResult.deployPermissions, {
   pages: 'write',
   'id-token': 'write',
 });
+assert.deepStrictEqual(expectedResult.buildConcurrency, {
+  group: buildConcurrencyGroup,
+  'cancel-in-progress': buildCancelInProgress,
+});
+assert.deepStrictEqual(expectedResult.deployConcurrency, {
+  group: deployConcurrencyGroup,
+  'cancel-in-progress': 'false',
+});
 assert(expectedResult.events.includes('pull_request'));
 
 function mayPublish({ eventName, ref }) {
@@ -40,15 +53,41 @@ function mayPublish({ eventName, ref }) {
 }
 
 const eventMatrix = [
-  { name: 'fork pull request', eventName: 'pull_request', ref: 'refs/pull/101/merge', publish: false },
-  { name: 'internal pull request', eventName: 'pull_request', ref: 'refs/pull/102/merge', publish: false },
-  { name: 'main push', eventName: 'push', ref: 'refs/heads/main', publish: true },
-  { name: 'main manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/main', publish: true },
-  { name: 'feature manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/feature', publish: false },
+  { name: 'fork pull request', eventName: 'pull_request', ref: 'refs/pull/101/merge', prNumber: 101, runId: 1001, publish: false },
+  { name: 'same pull request update', eventName: 'pull_request', ref: 'refs/pull/101/merge', prNumber: 101, runId: 1002, publish: false },
+  { name: 'internal pull request', eventName: 'pull_request', ref: 'refs/pull/102/merge', prNumber: 102, runId: 1003, publish: false },
+  { name: 'main push', eventName: 'push', ref: 'refs/heads/main', runId: 2001, publish: true },
+  { name: 'main manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/main', runId: 2002, publish: true },
+  { name: 'feature manual dispatch', eventName: 'workflow_dispatch', ref: 'refs/heads/feature', runId: 2003, publish: false },
 ];
+
+function concurrencyPolicy(scenario) {
+  const buildSuffix = scenario.eventName === 'pull_request'
+    ? `pr-${scenario.prNumber}`
+    : `run-${scenario.runId}`;
+  return {
+    buildGroup: `Build and Deploy (GitHub Actions)-build-${buildSuffix}`,
+    cancelBuildInProgress: scenario.eventName === 'pull_request',
+    deployGroup: mayPublish(scenario)
+      ? 'Build and Deploy (GitHub Actions)-pages-deploy'
+      : null,
+    cancelDeployInProgress: false,
+  };
+}
+
 for (const scenario of eventMatrix) {
   assert.strictEqual(mayPublish(scenario), scenario.publish, scenario.name);
 }
+const policies = eventMatrix.map(concurrencyPolicy);
+assert.strictEqual(policies[0].buildGroup, policies[1].buildGroup, 'same PR must share its build group');
+assert(policies[0].cancelBuildInProgress, 'same PR update must cancel the older build');
+assert.notStrictEqual(policies[0].buildGroup, policies[2].buildGroup, 'different PRs must not cancel each other');
+assert.notStrictEqual(policies[0].buildGroup, policies[3].deployGroup, 'PR build must not share the deploy group');
+assert.strictEqual(policies[3].deployGroup, policies[4].deployGroup, 'main push/manual deploys must serialize');
+assert(!policies[3].cancelDeployInProgress, 'a main push must not cancel an active deploy');
+assert(!policies[4].cancelDeployInProgress, 'a manual deploy must not cancel an active deploy');
+assert.notStrictEqual(policies[3].buildGroup, policies[4].buildGroup, 'non-PR builds must use unique run groups');
+assert.strictEqual(policies[5].deployGroup, null, 'feature manual run must not join the deploy group');
 
 const negativeFixtures = [
   {
@@ -107,6 +146,64 @@ const negativeFixtures = [
     name: 'missing pull_request event',
     source: source.replace('  pull_request:\n    branches: [ main ]\n', ''),
     message: /required block is missing: pull_request/,
+  },
+  {
+    name: 'workflow-level shared concurrency',
+    source: source.replace(
+      'permissions:\n  contents: read\n\njobs:',
+      'permissions:\n  contents: read\n\nconcurrency:\n  group: pages\n  cancel-in-progress: true\n\njobs:',
+    ),
+    message: /workflow-level concurrency must not mix/,
+  },
+  {
+    name: 'quoted workflow-level shared concurrency',
+    source: source.replace(
+      'permissions:\n  contents: read\n\njobs:',
+      'permissions:\n  contents: read\n\n"concurrency":\n  group: pages\n  cancel-in-progress: true\n\njobs:',
+    ),
+    message: /workflow-level concurrency must not mix/,
+  },
+  {
+    name: 'single-quoted workflow-level shared concurrency',
+    source: source.replace(
+      'permissions:\n  contents: read\n\njobs:',
+      "permissions:\n  contents: read\n\n'concurrency':\n  group: pages\n  cancel-in-progress: true\n\njobs:",
+    ),
+    message: /workflow-level concurrency must not mix/,
+  },
+  {
+    name: 'static PR build group',
+    source: source.replace(`      group: ${buildConcurrencyGroup}\n`, '      group: pages\n'),
+    message: /build concurrency mismatch/,
+  },
+  {
+    name: 'PR group without non-PR fallback',
+    source: source.replace(
+      `      group: ${buildConcurrencyGroup}\n`,
+      "      group: ${{ github.workflow }}-build-pr-${{ github.event.pull_request.number }}\n",
+    ),
+    message: /build concurrency mismatch/,
+  },
+  {
+    name: 'all builds cancel in progress',
+    source: source.replace(
+      `      cancel-in-progress: ${buildCancelInProgress}\n`,
+      '      cancel-in-progress: true\n',
+    ),
+    message: /build concurrency mismatch/,
+  },
+  {
+    name: 'deploy shares static pages group',
+    source: source.replace(`      group: ${deployConcurrencyGroup}\n`, '      group: pages\n'),
+    message: /deploy concurrency mismatch/,
+  },
+  {
+    name: 'deploy can be canceled',
+    source: source.replace(
+      `      group: ${deployConcurrencyGroup}\n      cancel-in-progress: false\n`,
+      `      group: ${deployConcurrencyGroup}\n      cancel-in-progress: true\n`,
+    ),
+    message: /deploy concurrency mismatch/,
   },
 ];
 

--- a/scripts/test-pages-template-permissions.js
+++ b/scripts/test-pages-template-permissions.js
@@ -7,6 +7,7 @@ const path = require('path');
 const {
   buildCancelInProgress,
   buildConcurrencyGroup,
+  decodeYamlDoubleQuotedScalar,
   deployConcurrencyGroup,
   validateWorkflow,
 } = require('./check-pages-template-permissions');
@@ -20,7 +21,23 @@ const workflowPath = path.join(
 const source = fs.readFileSync(workflowPath, 'utf8');
 const workflowNameMatch = source.match(/^name:\s*(.+)$/m);
 assert(workflowNameMatch, 'template must declare a workflow name');
-const workflowName = workflowNameMatch[1].trim();
+
+function parseWorkflowName(rawValue) {
+  const value = rawValue.trim();
+  if (value.startsWith('"') && value.endsWith('"')) {
+    const decoded = decodeYamlDoubleQuotedScalar(value);
+    assert.notStrictEqual(decoded, null, 'double-quoted workflow name must be valid');
+    return decoded;
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
+  return value;
+}
+
+const workflowName = parseWorkflowName(workflowNameMatch[1]);
+assert.strictEqual(parseWorkflowName('"Build and Deploy (GitHub Actions)"'), 'Build and Deploy (GitHub Actions)');
+assert.strictEqual(parseWorkflowName("'Build and Deploy (GitHub Actions)'"), 'Build and Deploy (GitHub Actions)');
 
 function replaceOccurrence(input, search, replacement, occurrence) {
   let from = 0;
@@ -180,6 +197,30 @@ const negativeFixtures = [
     source: source.replace(
       'permissions:\n  contents: read\n\njobs:',
       "permissions:\n  contents: read\n\n'concurrency':\n  group: pages\n  cancel-in-progress: true\n\njobs:",
+    ),
+    message: /workflow-level concurrency must not mix/,
+  },
+  {
+    name: 'hex-escaped workflow-level shared concurrency',
+    source: source.replace(
+      'permissions:\n  contents: read\n\njobs:',
+      'permissions:\n  contents: read\n\n"\\x63oncurrency":\n  group: pages\n  cancel-in-progress: true\n\njobs:',
+    ),
+    message: /workflow-level concurrency must not mix/,
+  },
+  {
+    name: 'unicode-escaped workflow-level shared concurrency',
+    source: source.replace(
+      'permissions:\n  contents: read\n\njobs:',
+      'permissions:\n  contents: read\n\n"\\u0063oncurrency":\n  group: pages\n  cancel-in-progress: true\n\njobs:',
+    ),
+    message: /workflow-level concurrency must not mix/,
+  },
+  {
+    name: 'long-unicode-escaped workflow-level shared concurrency',
+    source: source.replace(
+      'permissions:\n  contents: read\n\njobs:',
+      'permissions:\n  contents: read\n\n"\\U00000063oncurrency":\n  group: pages\n  cancel-in-progress: true\n\njobs:',
     ),
     message: /workflow-level concurrency must not mix/,
   },

--- a/scripts/test-pages-template-permissions.js
+++ b/scripts/test-pages-template-permissions.js
@@ -18,6 +18,9 @@ const workflowPath = path.join(
   'build-actions.yml',
 );
 const source = fs.readFileSync(workflowPath, 'utf8');
+const workflowNameMatch = source.match(/^name:\s*(.+)$/m);
+assert(workflowNameMatch, 'template must declare a workflow name');
+const workflowName = workflowNameMatch[1].trim();
 
 function replaceOccurrence(input, search, replacement, occurrence) {
   let from = 0;
@@ -66,10 +69,10 @@ function concurrencyPolicy(scenario) {
     ? `pr-${scenario.prNumber}`
     : `run-${scenario.runId}`;
   return {
-    buildGroup: `Build and Deploy (GitHub Actions)-build-${buildSuffix}`,
+    buildGroup: `${workflowName}-build-${buildSuffix}`,
     cancelBuildInProgress: scenario.eventName === 'pull_request',
     deployGroup: mayPublish(scenario)
-      ? 'Build and Deploy (GitHub Actions)-pages-deploy'
+      ? `${workflowName}-pages-deploy`
       : null,
     cancelDeployInProgress: false,
   };

--- a/templates/github-workflows/README.md
+++ b/templates/github-workflows/README.md
@@ -28,7 +28,15 @@
 `build-actions.yml`のdeploy条件は、`main`へのpushまたは`main`上の手動実行（`workflow_dispatch`）だけを許可します。
 `pull_request`イベントは、fork元にかかわらずbuild jobのbuild確認だけを実行し、Pagesへの書き込みやOIDC tokenの発行を行いません。
 
-concurrencyはjobの責務ごとに分離します。build jobはPR番号をgroupに含め、同一PRの古いbuildだけを新しい更新でcancelします。deploy対象となるmain pushとmain上の手動実行は共通のtrusted build groupに入れ、新しいrunが古いbuildをcancelすることで、遅い旧artifactが新しいcommitの後からdeployされるrollbackを防ぎます。deployしない非main手動buildだけは`github.run_id`で分離します。deploy jobはworkflow名を含む専用`pages-deploy` groupでmain pushとmain上の手動deployを直列化し、`cancel-in-progress: false`で進行中deployを保護します。GitHubの既定`single` pending契約を採用するため、deploy待機中に追加runが到着した場合は最新1件が古いpendingを置き換えます。PR buildとdeployはgroupを共有せず、fork PRからmain deployをcancelできません。詳細は[GitHub Actionsのconcurrency公式仕様](https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)を参照してください。
+concurrencyはjobの責務ごとに分離します。
+build jobはPR番号をgroupに含め、同一PRの古いbuildだけを新しい更新でcancelします。
+deploy対象となるmain pushとmain上の手動実行は共通のtrusted build groupに入れ、新しいrunが古いbuildをcancelすることで、遅い旧artifactが新しいcommitの後からdeployされるrollbackを防ぎます。
+deployしない非main手動buildだけは`github.run_id`で分離します。
+
+deploy jobはworkflow名を含む専用`pages-deploy` groupでmain pushとmain上の手動deployを直列化し、`cancel-in-progress: false`で進行中deployを保護します。
+GitHubの既定`single` pending契約を採用するため、deploy待機中に追加runが到着した場合は最新1件が古いpendingを置き換えます。
+PR buildとdeployはgroupを共有せず、fork PRからmain deployをcancelできません。
+詳細は[GitHub Actionsのconcurrency公式仕様](https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)を参照してください。
 
 両templateのremote Action参照は、監査済みのfull-length commit SHAとexact version commentを組にして管理します。
 copy後もmutableなmajor tagへ戻さず、更新時はupstream release/tag/commit、runtime、入出力、権限、transitive `uses:`を確認してください。

--- a/templates/github-workflows/README.md
+++ b/templates/github-workflows/README.md
@@ -28,6 +28,8 @@
 `build-actions.yml`のdeploy条件は、`main`へのpushまたは`main`上の手動実行（`workflow_dispatch`）だけを許可します。
 `pull_request`イベントは、fork元にかかわらずbuild jobのbuild確認だけを実行し、Pagesへの書き込みやOIDC tokenの発行を行いません。
 
+concurrencyはjobの責務ごとに分離します。build jobはPR番号をgroupに含め、同一PRの古いbuildだけを新しい更新でcancelします。PR以外のbuildは`github.run_id`で分離するため、main pushや手動実行を相互にcancelしません。deploy jobはworkflow名を含む専用`pages-deploy` groupでmain pushとmain上の手動deployを直列化し、`cancel-in-progress: false`で進行中deployを保護します。GitHubの既定`single` pending契約を採用するため、deploy待機中に追加runが到着した場合は最新1件が古いpendingを置き換えます。PR buildとdeployはgroupを共有せず、fork PRからmain deployをcancelできません。詳細は[GitHub Actionsのconcurrency公式仕様](https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)を参照してください。
+
 両templateのremote Action参照は、監査済みのfull-length commit SHAとexact version commentを組にして管理します。
 copy後もmutableなmajor tagへ戻さず、更新時はupstream release/tag/commit、runtime、入出力、権限、transitive `uses:`を確認してください。
 本リポジトリでは`config/action-pins.json`を監査記録の正本とし、`npm run test:action-pins`でactive workflowとtemplateのdriftを検出します。

--- a/templates/github-workflows/README.md
+++ b/templates/github-workflows/README.md
@@ -28,7 +28,7 @@
 `build-actions.yml`のdeploy条件は、`main`へのpushまたは`main`上の手動実行（`workflow_dispatch`）だけを許可します。
 `pull_request`イベントは、fork元にかかわらずbuild jobのbuild確認だけを実行し、Pagesへの書き込みやOIDC tokenの発行を行いません。
 
-concurrencyはjobの責務ごとに分離します。build jobはPR番号をgroupに含め、同一PRの古いbuildだけを新しい更新でcancelします。PR以外のbuildは`github.run_id`で分離するため、main pushや手動実行を相互にcancelしません。deploy jobはworkflow名を含む専用`pages-deploy` groupでmain pushとmain上の手動deployを直列化し、`cancel-in-progress: false`で進行中deployを保護します。GitHubの既定`single` pending契約を採用するため、deploy待機中に追加runが到着した場合は最新1件が古いpendingを置き換えます。PR buildとdeployはgroupを共有せず、fork PRからmain deployをcancelできません。詳細は[GitHub Actionsのconcurrency公式仕様](https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)を参照してください。
+concurrencyはjobの責務ごとに分離します。build jobはPR番号をgroupに含め、同一PRの古いbuildだけを新しい更新でcancelします。deploy対象となるmain pushとmain上の手動実行は共通のtrusted build groupに入れ、新しいrunが古いbuildをcancelすることで、遅い旧artifactが新しいcommitの後からdeployされるrollbackを防ぎます。deployしない非main手動buildだけは`github.run_id`で分離します。deploy jobはworkflow名を含む専用`pages-deploy` groupでmain pushとmain上の手動deployを直列化し、`cancel-in-progress: false`で進行中deployを保護します。GitHubの既定`single` pending契約を採用するため、deploy待機中に追加runが到着した場合は最新1件が古いpendingを置き換えます。PR buildとdeployはgroupを共有せず、fork PRからmain deployをcancelできません。詳細は[GitHub Actionsのconcurrency公式仕様](https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)を参照してください。
 
 両templateのremote Action参照は、監査済みのfull-length commit SHAとexact version commentを組にして管理します。
 copy後もmutableなmajor tagへ戻さず、更新時はupstream release/tag/commit、runtime、入出力、権限、transitive `uses:`を確認してください。

--- a/templates/github-workflows/build-actions.yml
+++ b/templates/github-workflows/build-actions.yml
@@ -14,10 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    # 同一PRの古いbuildだけをcancelする。非PR runはrun_idで分離する。
+    # 同一PRまたはtrusted mainの古いbuildをcancelし、stale artifactの後追いdeployを防ぐ。
+    # deployしない非main manual runだけはrun_idで分離する。
     concurrency:
-      group: ${{ github.workflow }}-build-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+      group: ${{ github.workflow }}-build-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.ref == 'refs/heads/main' && 'pages' || format('run-{0}', github.run_id)) }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
 
     # pull_request（forkを含む）は、このread-only jobだけを実行する。
     permissions:

--- a/templates/github-workflows/build-actions.yml
+++ b/templates/github-workflows/build-actions.yml
@@ -10,13 +10,14 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # 同一PRの古いbuildだけをcancelする。非PR runはrun_idで分離する。
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     # pull_request（forkを含む）は、このread-only jobだけを実行する。
     permissions:
@@ -54,6 +55,12 @@ jobs:
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: build
     runs-on: ubuntu-latest
+
+    # main push / main manual deployを直列化し、進行中deployはcancelしない。
+    # GitHubの既定single-pending契約により、待機中は最新1件を保持する。
+    concurrency:
+      group: ${{ github.workflow }}-pages-deploy
+      cancel-in-progress: false
 
     permissions:
       pages: write


### PR DESCRIPTION
## 概要

Pages templateのworkflow-level固定concurrencyを、PR buildとtrusted deployのjob-level groupへ分離します。

- 同一PRは`pr-<number>` groupで古いbuildだけをcancel
- main push / main上のmanual buildは共通trusted groupで古いbuildをcancelし、stale artifactの後追いdeployを防止
- 非main manual buildは`run_id` fallbackで分離
- main push / main manual deployは専用`pages-deploy` groupで直列化
- deployは`cancel-in-progress: false`とし、進行中deployを保護
- GitHub既定のsingle-pending（latest pending wins）方針をtemplate READMEへ明記
- dependency-free checker、7 event scenarios、1 positive / 19 negative fixturesで回帰防止
- YAML double-quoted key（`\x` / `\u` / `\U`を含む）とquoted workflow名を正規化し、escapeによる検査回避を防止

Refs #69.

## 設計上の前提

GitHub.comには`queue: max`がありますが、2026-07-19時点の最新actionlint release v1.7.12は未対応でupstream support PRも未mergeです。本PRはactionlint gateを維持し、既定single-pending契約を明示的に採用します。

## 検証

- `mise exec node@24 -- npm ci`
- `mise exec node@24 -- npm test`
  - actionlint v1.7.12: 6 workflow/template files
  - Pages template: 7 scenarios / 1 positive / 19 negative
- `mise exec node@24 -- npm audit --omit=dev --omit=optional`（0 vulnerabilities）
- `mise exec node@24 -- npm run check-external-links`（66 links）
- Jekyll build + root smoke
- `git diff --check`
- independent correctness review: actionable 0
- independent security review: quoted YAML key bypass（Medium）を修正後、actionable 0
- Codex P1 stale main build raceを修正後、targeted independent review actionable 0

## 実ランタイム制約

このファイルは配布templateであり、repositoryのactive deploy workflowではないため、PRで実際のcancel/queue E2Eは発火しません。GitHub公式仕様、actionlint、決定的event matrix/negative fixturesで検証します。operatorが古いrunを明示的にrerunするhistorical redeployは通常concurrency raceと異なるため、本Issueの対象外です。

